### PR TITLE
Enabling Cassini perspective

### DIFF
--- a/src/python/animate_batch.py
+++ b/src/python/animate_batch.py
@@ -65,7 +65,7 @@ for it1 in range(3, len(time) + 1, 4):
                 vort = nc.variables["vort"][:]
                 nc.close()
                 # set up orthographic map projection
-                x, y, basemap = create_map_func(lons, lats)
+                x, y, basemap = create_map_func(lons, lats, 1200000)
                 # contour data over the map.
                 # cs = basemap.contour(x,y,wave+mean,15,linewidths=1.5)
                 cs1 = basemap.pcolor(x, y, vort[it, :, :], cmap="jet")

--- a/src/python/animate_output.py
+++ b/src/python/animate_output.py
@@ -105,6 +105,7 @@ for it1 in range(4, len(time) + 1, 4):
     it = it1 - 1
     f = plt.figure()
 
+<<<<<<< HEAD
     ax1 = make_maps(h[it, :, :], f.add_subplot(141), 60000, 64000, "h", "m", "Height")
     ax2 = make_maps(
         vort[it, :, :],
@@ -117,6 +118,71 @@ for it1 in range(4, len(time) + 1, 4):
     )
     ax3 = make_maps(v[it, :, :], f.add_subplot(143), -7, 7, "v", "m s$^{-1}$", "v")
     ax4 = make_maps(u[it, :, :], f.add_subplot(144), -5, 60, "u", "m s$^{-1}$", "u")
+=======
+    ax1 = f.add_subplot(141)
+    # set up orthographic map projection
+    x, y, basemap = create_map_func(lons, lats, 1400000)
+    # contour data over the basemap.
+    # cs = basemap.contour(x,y,wave+mean,15,linewidths=1.5)
+    cs1 = basemap.pcolor(
+        x, y, h[it, :, :], cmap="jet", shading="auto", vmin=60000, vmax=64000
+    )
+    cbar = basemap.colorbar(location="bottom")
+    cbar.ax.set_xticks(cbar.ax.get_xticks())
+    cbar.ax.set_xticklabels(cbar.ax.get_xticklabels(), rotation="horizontal", fontsize=8)
+    # Format colorbar tick labels using scientific notation
+    formatter = ticker.ScalarFormatter(useMathText=True)
+    formatter.set_powerlimits((-3, 3))  # Adjust the limits as needed
+    cbar.ax.xaxis.set_major_formatter(formatter)
+    power_text = cbar.ax.xaxis.get_offset_text()
+    power_text.set_size(8)
+    # Set label and title
+    cbar.set_label("h, m", fontsize=8)
+    ax1.set_title("Height", fontsize=8)
+
+    ax2 = f.add_subplot(142)
+    # set up orthographic map projection
+    x, y, basemap = create_map_func(lons, lats, 1400000)
+    # contour data over the basemap.
+    cs2 = basemap.pcolor(
+        x, y, vort[it, :, :], cmap="jet", shading="auto", vmin=-0.00005, vmax=0.00005
+    )
+    cbar = basemap.colorbar(location="bottom")
+    cbar.ax.set_xticks(cbar.ax.get_xticks())
+    cbar.ax.set_xticklabels(cbar.ax.get_xticklabels(), rotation="horizontal", fontsize=8)
+    # Format colorbar tick labels using scientific notation
+    formatter = ticker.ScalarFormatter(useMathText=True)
+    formatter.set_powerlimits((-3, 3))  # Adjust the limits as needed
+    cbar.ax.xaxis.set_major_formatter(formatter)
+    power_text = cbar.ax.xaxis.get_offset_text()
+    power_text.set_size(8)
+    # Set label and title
+    cbar.set_label("$\\zeta$, s$^{-1}$", fontsize=8)
+    ax2.set_title("Vorticity", fontsize=8)
+
+    ax3 = f.add_subplot(143)
+    # set up orthographic map projection
+    x, y, basemap = create_map_func(lons, lats, 1400000)
+    # contour data over the basemap.
+    cs3 = basemap.pcolor(x, y, v[it, :, :], cmap="jet", shading="auto", vmin=-7, vmax=7)
+    cbar = basemap.colorbar(location="bottom")
+    cbar.ax.set_xticklabels(cbar.ax.get_xticklabels(), rotation="horizontal", fontsize=8)
+    cbar.set_label("v, m s$^{-1}$", fontsize=8)
+    ax3.set_title("v", fontsize=8)
+
+    ax4 = f.add_subplot(144)
+    # set up orthographic map projection
+    x, y, basemap = create_map_func(lons, lats, 1400000)
+    # contour data over the basemap.
+    # cs = basemap.contour(x,y,wave+mean,15,linewidths=1.5)
+    cs4 = basemap.pcolor(
+        x, y, u[it, :, :], cmap="jet", shading="auto", vmin=-5, vmax=60
+    )
+    cbar = basemap.colorbar(location="bottom")
+    cbar.ax.set_xticklabels(cbar.ax.get_xticklabels(), rotation="horizontal", fontsize=8)
+    cbar.set_label("u, m s$^{-1}$", fontsize=8)
+    ax4.set_title("u", fontsize=8)
+>>>>>>> aef4e0e (Rebasing with the May 9th config changes)
 
     ITER += 1
     plt.suptitle(f"t={time[it]/86400:.2f} days", fontsize=8, y=0.25)

--- a/src/python/animate_output.py
+++ b/src/python/animate_output.py
@@ -24,10 +24,10 @@ from create_map import create_map_func
 from netCDF4 import Dataset as NetCDFFile
 
 matplotlib.use("Agg")
-
 warnings.filterwarnings("ignore")
-
 username = getpass.getuser()
+
+CASSINI_PERSPECTIVE = True
 
 nc = NetCDFFile("../../tests/output.nc")
 lons = nc.variables["phi"][:]
@@ -69,7 +69,10 @@ def make_maps(data, ax, vmin_var, vmax_var, colourbar_label_var, colourbar_units
             The modified axes containing the map plot.
     """
     # set up orthographic map projection
-    x, y, basemap = create_map_func(lons, lats)
+    if CASSINI_PERSPECTIVE:
+        x, y, basemap = create_map_func(lons, lats, 1400000, 82)
+    else:
+        x, y, basemap = create_map_func(lons, lats)
     # contour data over the basemap
     basemap.pcolor(x, y, data, cmap="jet", shading="auto", vmin=vmin_var, vmax=vmax_var)
     cbar = basemap.colorbar(location="bottom", pad=0.05)
@@ -105,7 +108,6 @@ for it1 in range(4, len(time) + 1, 4):
     it = it1 - 1
     f = plt.figure()
 
-<<<<<<< HEAD
     ax1 = make_maps(h[it, :, :], f.add_subplot(141), 60000, 64000, "h", "m", "Height")
     ax2 = make_maps(
         vort[it, :, :],
@@ -118,71 +120,6 @@ for it1 in range(4, len(time) + 1, 4):
     )
     ax3 = make_maps(v[it, :, :], f.add_subplot(143), -7, 7, "v", "m s$^{-1}$", "v")
     ax4 = make_maps(u[it, :, :], f.add_subplot(144), -5, 60, "u", "m s$^{-1}$", "u")
-=======
-    ax1 = f.add_subplot(141)
-    # set up orthographic map projection
-    x, y, basemap = create_map_func(lons, lats, 1400000)
-    # contour data over the basemap.
-    # cs = basemap.contour(x,y,wave+mean,15,linewidths=1.5)
-    cs1 = basemap.pcolor(
-        x, y, h[it, :, :], cmap="jet", shading="auto", vmin=60000, vmax=64000
-    )
-    cbar = basemap.colorbar(location="bottom")
-    cbar.ax.set_xticks(cbar.ax.get_xticks())
-    cbar.ax.set_xticklabels(cbar.ax.get_xticklabels(), rotation="horizontal", fontsize=8)
-    # Format colorbar tick labels using scientific notation
-    formatter = ticker.ScalarFormatter(useMathText=True)
-    formatter.set_powerlimits((-3, 3))  # Adjust the limits as needed
-    cbar.ax.xaxis.set_major_formatter(formatter)
-    power_text = cbar.ax.xaxis.get_offset_text()
-    power_text.set_size(8)
-    # Set label and title
-    cbar.set_label("h, m", fontsize=8)
-    ax1.set_title("Height", fontsize=8)
-
-    ax2 = f.add_subplot(142)
-    # set up orthographic map projection
-    x, y, basemap = create_map_func(lons, lats, 1400000)
-    # contour data over the basemap.
-    cs2 = basemap.pcolor(
-        x, y, vort[it, :, :], cmap="jet", shading="auto", vmin=-0.00005, vmax=0.00005
-    )
-    cbar = basemap.colorbar(location="bottom")
-    cbar.ax.set_xticks(cbar.ax.get_xticks())
-    cbar.ax.set_xticklabels(cbar.ax.get_xticklabels(), rotation="horizontal", fontsize=8)
-    # Format colorbar tick labels using scientific notation
-    formatter = ticker.ScalarFormatter(useMathText=True)
-    formatter.set_powerlimits((-3, 3))  # Adjust the limits as needed
-    cbar.ax.xaxis.set_major_formatter(formatter)
-    power_text = cbar.ax.xaxis.get_offset_text()
-    power_text.set_size(8)
-    # Set label and title
-    cbar.set_label("$\\zeta$, s$^{-1}$", fontsize=8)
-    ax2.set_title("Vorticity", fontsize=8)
-
-    ax3 = f.add_subplot(143)
-    # set up orthographic map projection
-    x, y, basemap = create_map_func(lons, lats, 1400000)
-    # contour data over the basemap.
-    cs3 = basemap.pcolor(x, y, v[it, :, :], cmap="jet", shading="auto", vmin=-7, vmax=7)
-    cbar = basemap.colorbar(location="bottom")
-    cbar.ax.set_xticklabels(cbar.ax.get_xticklabels(), rotation="horizontal", fontsize=8)
-    cbar.set_label("v, m s$^{-1}$", fontsize=8)
-    ax3.set_title("v", fontsize=8)
-
-    ax4 = f.add_subplot(144)
-    # set up orthographic map projection
-    x, y, basemap = create_map_func(lons, lats, 1400000)
-    # contour data over the basemap.
-    # cs = basemap.contour(x,y,wave+mean,15,linewidths=1.5)
-    cs4 = basemap.pcolor(
-        x, y, u[it, :, :], cmap="jet", shading="auto", vmin=-5, vmax=60
-    )
-    cbar = basemap.colorbar(location="bottom")
-    cbar.ax.set_xticklabels(cbar.ax.get_xticklabels(), rotation="horizontal", fontsize=8)
-    cbar.set_label("u, m s$^{-1}$", fontsize=8)
-    ax4.set_title("u", fontsize=8)
->>>>>>> aef4e0e (Rebasing with the May 9th config changes)
 
     ITER += 1
     plt.suptitle(f"t={time[it]/86400:.2f} days", fontsize=8, y=0.25)

--- a/src/python/create_map.py
+++ b/src/python/create_map.py
@@ -11,7 +11,7 @@ map coordinate matrices.
 import numpy as np
 from mpl_toolkits.basemap import Basemap
 
-def create_map_func(lons, lats, satellite_height):
+def create_map_func(lons, lats, satellite_height=3000000, satellite_angle=90):
     """
     Draw an orthographic map projection with perspective of satellite 
     looking down at 50N, 100W.
@@ -19,8 +19,10 @@ def create_map_func(lons, lats, satellite_height):
     Parameters:
         lons (numpy.ndarray): 1D array of longitudes.
         lats (numpy.ndarray): 1D array of latitudes.
-        wave (numpy.ndarray): 2D array of wave data.
-        mean (numpy.ndarray): 2D array of mean data.
+        satellite_height (float): The height we want the map to be
+                                  displayed from, from Saturn's core.
+        satellite_angle (float): Angle from which to view the Saturn
+                                 map.
 
     Returns:
         tuple: A tuple containing the meshgrid x and y coordinates.
@@ -31,7 +33,7 @@ def create_map_func(lons, lats, satellite_height):
     basemap = Basemap(
         satellite_height=satellite_height,
         projection="nsper",
-        lat_0=82,
+        lat_0=satellite_angle,
         lon_0=-100,
         resolution="l",
     )

--- a/src/python/create_map.py
+++ b/src/python/create_map.py
@@ -11,7 +11,7 @@ map coordinate matrices.
 import numpy as np
 from mpl_toolkits.basemap import Basemap
 
-def create_map_func(lons, lats):
+def create_map_func(lons, lats, satellite_height):
     """
     Draw an orthographic map projection with perspective of satellite 
     looking down at 50N, 100W.
@@ -29,9 +29,9 @@ def create_map_func(lons, lats):
                And also the Basemap object.
     """
     basemap = Basemap(
-        satellite_height=3000000,
+        satellite_height=satellite_height,
         projection="nsper",
-        lat_0=90,
+        lat_0=82,
         lon_0=-100,
         resolution="l",
     )


### PR DESCRIPTION
Rebasing the Cassini perspective branch with the added scientific/mathematical notation.
Adding option to display the branch from the 'Cassini' perspective, hereby showing the spherical nature of the simulation.

![cassini_perspective](https://github.com/petrafisher-code/ShallowWaterModelCode/assets/73986146/816c9e2a-f53f-4bbf-855a-b860c2690502)
