### PR TITLE
New equations in conservative form

### DIFF
--- a/config/namelist.in
+++ b/config/namelist.in
@@ -21,7 +21,7 @@
 	nm1%cvis=0.2, ! usually between 0.1 and 0.2
 	nm1%vis_eq=1.e8, ! viscosity for v over equator region
 	nm1%lat_eq=20., ! latitude north and south over which to apply vis_eq
-	nm1%runtime= 7819200.,
+	nm1%runtime= 7819200., !864000.,
 	nm1%dt=60.,
 	nm1%output_interval=57600.,
 	nm1%grav=10.44,		! gravity

--- a/config/namelist.in
+++ b/config/namelist.in
@@ -21,7 +21,7 @@
 	nm1%cvis=0.2, ! usually between 0.1 and 0.2
 	nm1%vis_eq=1.e8, ! viscosity for v over equator region
 	nm1%lat_eq=20., ! latitude north and south over which to apply vis_eq
-	nm1%runtime= 7819200., !864000.,
+	nm1%runtime= 2592000 ! 7819200., ! 864000.,
 	nm1%dt=60.,
 	nm1%output_interval=57600.,
 	nm1%grav=10.44,		! gravity
@@ -34,4 +34,5 @@
 	nm1%slat=-90.,
 	nm1%nlat=90.,
 	nm1%slat_thresh=65.,
-	nm1%nlat_thresh=86.5/
+	nm1%nlat_thresh=86.5,
+	nm1%new_eqs=.true/

--- a/config/namelist.in
+++ b/config/namelist.in
@@ -21,7 +21,7 @@
 	nm1%cvis=0.2, ! usually between 0.1 and 0.2
 	nm1%vis_eq=1.e8, ! viscosity for v over equator region
 	nm1%lat_eq=20., ! latitude north and south over which to apply vis_eq
-	nm1%runtime= 2592000 ! 7819200., ! 864000.,
+	nm1%runtime=    2592000., ! 864000., ! 7819200.,
 	nm1%dt=60.,
 	nm1%output_interval=57600.,
 	nm1%grav=10.44,		! gravity

--- a/config/namelist.in
+++ b/config/namelist.in
@@ -21,7 +21,7 @@
 	nm1%cvis=0.2, ! usually between 0.1 and 0.2
 	nm1%vis_eq=1.e8, ! viscosity for v over equator region
 	nm1%lat_eq=20., ! latitude north and south over which to apply vis_eq
-	nm1%runtime=    2592000., ! 864000., ! 7819200.,
+	nm1%runtime= 2592000., ! 7819200., ! 864000.,
 	nm1%dt=60.,
 	nm1%output_interval=57600.,
 	nm1%grav=10.44,		! gravity

--- a/src/advection.f90
+++ b/src/advection.f90
@@ -5,7 +5,7 @@
     module advection
     use numerics_type
     private
-    public :: lax_wendroff_sphere, lax_wendroff_ll, dissipation, smagorinsky
+    public :: lax_wendroff_sphere, lax_wendroff_conservative, lax_wendroff_ll, dissipation, smagorinsky
     contains
 	!>@author
 	!>Paul J. Connolly, The University of Manchester
@@ -175,6 +175,161 @@
 		h(1:ip,1:jp) = h_new
 
 	end subroutine lax_wendroff_sphere
+
+		!>@author
+	!>Paul J. Connolly, The University of Manchester
+	!>@brief
+	!>advects a scalar field on a ll grid 
+	!>@param[in] ip: number of east-west points
+	!>@param[in] jp: ditto for north-south
+	!>@param[in] o_halo: halos required for advection scheme
+	!>@param[in] dt:  timestep
+	!>@param[in] g: gravity
+	!>@param[inout] u,v,h: prognostic variables
+	!>@param[in] hs: surface height
+	!>@param[in] re: radius of planet
+	!>@param[in] theta: latitude
+	!>@param[in] thetan: latitude - staggered
+	!>@param[in] dtheta: latitude step
+	!>@param[in] dthetan: latitude step - staggered
+	!>@param[in] phi: phi
+	!>@param[in] phin: phin
+	!>@param[in] dphi: dphi
+	!>@param[in] dphin: dphin
+	!>@param[in] f_cor: Coriolis parameter
+	!>@param[in] recqdq - for efficiency
+	!>@param[in] recqdp - for efficiency
+	!>@param[in] recqdp_s - for efficiency
+	!>@param[in] recqdq_s - for efficiency
+	!>@param[in] redq_s - for efficiency
+	!>@param[in] redq - for efficiency
+	!>@param[in] rect - for efficiency
+	!>@param[in] rect_s - for efficiency
+	!>@param[in] cq - for efficiency
+	!>@param[in] cq_s - for efficiency
+	!>solves the 1-d advection equation:
+	!>\f$ \frac{\partial \psi}{\partial t} + \frac{\partial u \psi}{\partial x} = 0 \f$
+    subroutine lax_wendroff_conservative(ip,jp,o_halo,dt,g,u,v,h,hs,re,&
+		theta,thetan,dtheta,dthetan, phi, phin, dphi, dphin, f_cor, &
+		recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, rect, rect_s, cq, cq_s)
+
+		use numerics_type
+		implicit none
+		integer(i4b), intent(in) :: ip,jp,o_halo
+		real(wp), intent(in) :: dt, g, re
+		real(wp), intent(in), dimension(1-o_halo:ip+o_halo,1-o_halo:jp+o_halo) :: &
+																		hs, f_cor, &
+					recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, rect, &
+					rect_s, cq, cq_s
+		real(wp), dimension(1-o_halo:jp+o_halo), intent(in) :: &
+											theta,thetan, dtheta, dthetan
+		real(wp), dimension(1-o_halo:ip+o_halo), intent(in) :: &											
+											phi, phin, dphi, dphin
+		real(wp), intent(inout), dimension(1-o_halo:ip+o_halo,1-o_halo:jp+o_halo) :: &
+																				h, u, v
+																				
+		! local variables:
+		real(wp), dimension(1-o_halo:ip+o_halo,1-o_halo:jp+o_halo) :: & 
+					dy1, v1, h1, vh, uh, vh1, Ux, Uy, Vx, Vy, Vy2, uv, u2
+		real(wp), dimension(1:ip,1:jp) :: &
+										uh_new, vh_new, h_new
+										
+		real(wp), dimension(0:ip,1:jp) :: h_mid_xt, uh_mid_xt, Ux_mid_xt, Vx_mid_xt
+		real(wp), dimension(0:ip,1:jp) :: vh_mid_xt
+		real(wp), dimension(1:ip,0:jp) :: h_mid_yt, uh_mid_yt, vh_mid_yt,  &
+												Uy_mid_yt, Vy_mid_yt, Vy_mid_yt2
+		integer(i4b) :: j, i
+			
+		
+		v1=v*cq ! cq=cos(theta)
+		h1=h*cq
+		
+		uh=u *h
+		vh=v*h
+		vh1=v1*h
+		
+		! continuity equation (calculate mid-point values at 0.5*dt):
+		h_mid_xt = 0.5_wp*(h(1:ip+1,1:jp)+h(0:ip,1:jp)) &
+		-(0.5_wp*dt/(recqdp_s(0:ip,1:jp))) &
+		*(uh(1:ip+1,1:jp)-uh(0:ip,1:jp))
+		
+		h_mid_yt = 0.5_wp*(h(1:ip,1:jp+1)+h(1:ip,0:jp)) &
+		-(0.5_wp*dt/(recqdq_s(1:ip,0:jp))) &
+		*(vh1(1:ip,1:jp+1)-vh1(1:ip,0:jp))
+
+		! v-phi, or u momentum equation (calculate mid-point values at 0.5*dt):
+		Ux = uh*u + g*h**2*(0.5_wp)
+		Uy = uh*v1
+		uh_mid_xt(0:ip,:) = 0.5_wp*(uh(1:ip+1,1:jp)+uh(0:ip,1:jp)) &
+		-(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))* &
+			(Ux(1:ip+1,1:jp)-Ux(0:ip,1:jp)) &
+		+0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))* &
+			(vh(1:ip+1,1:jp)+vh(0:ip,1:jp))
+		
+		uh_mid_yt = 0.5_wp*(uh(1:ip,1:jp+1)+uh(1:ip,0:jp)) &
+		-(0.5_wp*dt/(recqdq_s(1:ip,0:jp)))* &
+			(Uy(1:ip,1:jp+1)-Uy(1:ip,0:jp)) &
+		+0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))* &
+			(vh(1:ip,1:jp+1)+vh(1:ip,0:jp))
+
+		! v-theta, or v momentum equation (calculate mid-point values at 0.5*dt):
+		Vx = uh*v
+		Vy = vh1*v
+		Vy2 = 0.5_wp*g*h**2
+		vh_mid_xt(0:ip,1:jp) = 0.5_wp*(vh(1:ip+1,1:jp)+vh(0:ip,1:jp)) &
+		-(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*(Vx(1:ip+1,1:jp)-Vx(0:ip,1:jp)) &
+		-0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))*(uh(1:ip+1,1:jp)+uh(0:ip,1:jp))
+
+		vh_mid_yt(1:ip,0:jp) = 0.5_wp*(vh(1:ip,1:jp+1)+vh(1:ip,0:jp)) &
+		-(0.5_wp*dt/(recqdq_s(1:ip,0:jp)))*(Vy(1:ip,1:jp+1)-Vy(1:ip,0:jp)) &
+		-(0.5_wp*dt/(redq_s(1:ip,0:jp)))*(Vy2(1:ip,1:jp+1)-Vy2(1:ip,0:jp)) &
+		-0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))*(uh(1:ip,1:jp+1)+uh(1:ip,0:jp))
+
+		! calculate mid-point value of cos (theta)
+		! c_mid_yt=cos(0.5.*(THETA(:,2:end)+THETA(:,1:end-1)));
+
+		! Now use the mid-point values to predict the values at the next timestep
+		! continuity:
+		h_new = h(1:ip,1:jp) &
+		- (dt/(recqdp(0:ip-1,1:jp)))*(uh_mid_xt(1:ip,1:jp)-uh_mid_xt(0:ip-1,1:jp)) &
+		- (dt/(recqdq(1:ip,0:jp-1))) * &
+		(vh_mid_yt(1:ip,1:jp)*cq_s(1:ip,1:jp)-vh_mid_yt(1:ip,0:jp-1)*cq_s(1:ip,0:jp-1))
+
+
+		! u-momentum equation:
+		Ux_mid_xt = uh_mid_xt*uh_mid_xt/h_mid_xt + 0.5_wp*g*h_mid_xt**2
+		Uy_mid_yt = uh_mid_yt*vh_mid_yt/h_mid_yt*cq_s(1:ip,0:jp)
+		uh_new = uh(1:ip,1:jp) &
+		- (dt/(recqdp(0:ip-1,1:jp)))*  (Ux_mid_xt(1:ip,1:jp)-Ux_mid_xt(0:ip-1,1:jp)) &
+		- (dt/(recqdq(1:ip,0:jp-1)))*(Uy_mid_yt(1:ip,1:jp)-Uy_mid_yt(1:ip,0:jp-1))
+
+
+		! v-momentum equation:
+		Vx_mid_xt = uh_mid_xt*vh_mid_xt/h_mid_xt
+		Vy_mid_yt = vh_mid_yt*vh_mid_yt/h_mid_yt*cq_s(1:ip,0:jp)
+		Vy_mid_yt2 = 0.5_wp*g*h_mid_yt**2
+		vh_new = vh(1:ip,1:jp) &
+		- (dt/(recqdp(0:ip-1,1:jp)))*(Vx_mid_xt(1:ip,1:jp)-Vx_mid_xt(0:ip-1,1:jp)) &
+		- (dt/(recqdq(1:ip,0:jp-1)))*(Vy_mid_yt(1:ip,1:jp)-Vy_mid_yt(1:ip,0:jp-1)) &
+		- (dt/(redq(1:ip,0:jp-1) ))* &
+		(Vy_mid_yt2(1:ip,1:jp)-Vy_mid_yt2(1:ip,0:jp-1))
+
+
+		! add on Coriolis and contribution of orography to pressure gradient:
+		uv = u*v
+		u2 = u*u
+		uh_new=uh_new + dt*.5_wp*(f_cor(1:ip,1:jp)*v(1:ip,1:jp) & 
+			- uv(1:ip,1:jp)*rect(1:ip,1:jp))*(h(1:ip,1:jp)+h_new)
+
+		vh_new=vh_new - dt*.5_wp*(f_cor(1:ip,1:jp)*u(1:ip,1:jp) & 
+			+ u2(1:ip,1:jp)*rect(1:ip,1:jp))*(h(1:ip,1:jp)+h_new)
+
+		! re-calculate u and v.
+		u(1:ip,1:jp) = uh_new/(h_new)
+		v(1:ip,1:jp) = vh_new/h_new
+		h(1:ip,1:jp) = h_new
+
+	end subroutine lax_wendroff_conservative
 	
 	!>@author
 	!>Paul J. Connolly, The University of Manchester
@@ -429,7 +584,7 @@
 		
 		! calculate viscosity using centred differences:
 		vis(1:ip,1:jp) = cvis**2._wp*re*recq(1:ip,1:jp)*dp1(1:ip,1:jp)*dq(1:ip,1:jp)* &
-		sqrt( ( (u(2:ip+1,1:jp)-u(0:ip-1,1:jp))/ &
+			sqrt( ( (u(2:ip+1,1:jp)-u(0:ip-1,1:jp))/ &
 			(recq(1:ip,1:jp)*(dp1(0:ip-1,1:jp)+dp1(1:ip,1:jp))) )**2._wp + &
 			( (v(1:ip,2:jp+1)-v(1:ip,0:jp-1))/ &
 			(re*(dq(1:ip,1:jp)+dq(1:ip,0:jp-1))) )**2._wp + &

--- a/src/advection.f90
+++ b/src/advection.f90
@@ -10,7 +10,7 @@
 	!>@author
 	!>Paul J. Connolly, The University of Manchester
 	!>@brief
-	!>advects a scalar field on the sphere 
+	!>advects a scalar field on a sphere 
 	!>@param[in] ip: number of east-west points
 	!>@param[in] jp: ditto for north-south
 	!>@param[in] o_halo: halos required for advection scheme
@@ -21,42 +21,60 @@
 	!>@param[in] hs: surface height
 	!>@param[in] re: radius of planet
 	!>@param[in] theta: latitude
+	!>@param[in] thetan: latitude - staggered
+	!>@param[in] dtheta: latitude step
+	!>@param[in] dthetan: latitude step - staggered
+	!>@param[in] phi: phi
+	!>@param[in] phin: phin
+	!>@param[in] dphi: dphi
+	!>@param[in] dphin: dphin
 	!>@param[in] f_cor: Coriolis parameter
+	!>@param[in] recqdq - for efficiency
+	!>@param[in] recqdp - for efficiency
+	!>@param[in] recqdp_s - for efficiency
+	!>@param[in] recqdq_s - for efficiency
+	!>@param[in] redq_s - for efficiency
+	!>@param[in] redq - for efficiency
+	!>@param[in] rect - for efficiency
+	!>@param[in] rect_s - for efficiency
+	!>@param[in] cq - for efficiency
+	!>@param[in] cq_s - for efficiency
 	!>solves the 1-d advection equation:
 	!>\f$ \frac{\partial \psi}{\partial t} + \frac{\partial u \psi}{\partial x} = 0 \f$
-    subroutine lax_wendroff_sphere(ip,jp,o_halo,dt,dx,dy,g,u,v,h,hs,re,theta,f_cor)
+    subroutine lax_wendroff_sphere(ip,jp,o_halo,dt,g,u,v,h,hs,re,&
+		theta,thetan,dtheta,dthetan, phi, phin, dphi, dphin, f_cor, &
+		recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, rect, rect_s, cq, cq_s)
 
 		use numerics_type
 		implicit none
 		integer(i4b), intent(in) :: ip,jp,o_halo
 		real(wp), intent(in) :: dt, g, re
 		real(wp), intent(in), dimension(1-o_halo:ip+o_halo,1-o_halo:jp+o_halo) :: &
-																		hs, f_cor, dx, dy
-		real(wp), dimension(1-o_halo:jp+o_halo), intent(in) :: theta
+																		hs, f_cor, &
+					recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, rect, &
+					rect_s, cq, cq_s
+		real(wp), dimension(1-o_halo:jp+o_halo), intent(in) :: &
+											theta,thetan, dtheta, dthetan
+		real(wp), dimension(1-o_halo:ip+o_halo), intent(in) :: &											
+											phi, phin, dphi, dphin
 		real(wp), intent(inout), dimension(1-o_halo:ip+o_halo,1-o_halo:jp+o_halo) :: &
 																				h, u, v
 																				
 		! local variables:
 		real(wp), dimension(1-o_halo:ip+o_halo,1-o_halo:jp+o_halo) :: & 
-					dy1, v1, h1, vh, uh, vh1, Ux, Uy, Vx, Vy, Vy2
+					dy1, v1, h1, vh, uh, vh1, Ux, Uy, Vx, Vy, uv, u2
 		real(wp), dimension(1:ip,1:jp) :: &
-									    uh_new, vh_new, h_new
+										u_new, v_new, h_new
 										
-		real(wp), dimension(0:ip,1:jp) :: h_mid_xt, uh_mid_xt, Ux_mid_xt, Vx_mid_xt
-		real(wp), dimension(0:ip,1:jp) :: vh_mid_xt
-		real(wp), dimension(1:ip,0:jp) :: h_mid_yt, uh_mid_yt, vh_mid_yt, c_mid_yt, &
-		 									Uy_mid_yt, Vy_mid_yt, Vy_mid_yt2
+		real(wp), dimension(0:ip,1:jp) :: h_mid_xt, u_mid_xt, Ux_mid_xt, Vx_mid_xt
+		real(wp), dimension(0:ip,1:jp) :: v_mid_xt
+		real(wp), dimension(1:ip,0:jp) :: h_mid_yt, u_mid_yt, v_mid_yt,  &
+											Uy_mid_yt, Vy_mid_yt
 		integer(i4b) :: j, i
 			
 		
-		do j=1-o_halo,jp+o_halo
-			dy1(:,j)=dy(:,j)*cos(theta(j))
-			v1(:,j)=v(:,j)*cos(theta(j))
-			h1(:,j)=h(:,j)*cos(theta(j))
-		enddo
-		do j=0,jp
-			c_mid_yt(:,j)=cos(0.5_wp*(theta(j+1)+theta(j)))
-		enddo
+		v1=v*cq ! cq=cos(theta)
+		h1=h*cq
 		
 		uh=u *h
 		vh=v*h
@@ -64,100 +82,97 @@
 		
 		! continuity equation (calculate mid-point values at 0.5*dt):
 		h_mid_xt = 0.5_wp*(h(1:ip+1,1:jp)+h(0:ip,1:jp)) &
-		  -(0.5_wp*dt/(0.5_wp*(dx(1:ip+1,1:jp)+dx(0:ip,1:jp)))) &
-		  *(uh(1:ip+1,1:jp)-uh(0:ip,1:jp))
-		  
-		h_mid_yt = 0.5_wp*(h(1:ip,1:jp+1)+h(1:ip,0:jp)) &
-		  -(0.5_wp*dt/(0.5_wp*(dy1(1:ip,1:jp+1)+dy1(1:ip,0:jp)))) &
-		  *(vh1(1:ip,1:jp+1)-vh1(1:ip,0:jp))
-
-		! v-phi, or u momentum equation (calculate mid-point values at 0.5*dt):
-		Ux = uh*u + g*h**2*(0.5_wp)
-		Uy = uh*v1
-		uh_mid_xt(0:ip,:) = 0.5_wp*(uh(1:ip+1,1:jp)+uh(0:ip,1:jp)) &
-		  -(0.5_wp*dt/(0.5_wp*(dx(1:ip+1,1:jp)+dx(0:ip,1:jp))))* &
-		  	(Ux(1:ip+1,1:jp)-Ux(0:ip,1:jp)) &
-		  +0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))* &
-		  	(vh(1:ip+1,1:jp)+vh(0:ip,1:jp))
+		-(0.5_wp*dt/(recqdp_s(0:ip,1:jp))) &
+		*(uh(1:ip+1,1:jp)-uh(0:ip,1:jp))
 		
-		uh_mid_yt = 0.5_wp*(uh(1:ip,1:jp+1)+uh(1:ip,0:jp)) &
-		  -(0.5_wp*dt/(0.5_wp*(dy1(1:ip,1:jp+1)+dy1(1:ip,0:jp))))* &
-		  	(Uy(1:ip,1:jp+1)-Uy(1:ip,0:jp)) &
-		  +0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))* &
-		  	(vh(1:ip,1:jp+1)+vh(1:ip,0:jp))
+		h_mid_yt = 0.5_wp*(h(1:ip,1:jp+1)+h(1:ip,0:jp)) &
+		-(0.5_wp*dt/(recqdq_s(1:ip,0:jp))) &
+		*(vh1(1:ip,1:jp+1)-vh1(1:ip,0:jp))
 
+		! !2 v-phi, or u momentum equation (calculate mid-point values at 0.5*dt):
+		! Ux = u*u
+		! Uy = u*v
+		! u_mid_xt(0:ip,:) = 0.5_wp*(u(1:ip+1,1:jp)+u(0:ip,1:jp)) &
+		! -(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))* &
+		! 	(Ux(1:ip+1,1:jp)-Ux(0:ip,1:jp)) &
+		! +0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))* &
+		! 	(v(1:ip+1,1:jp)+v(0:ip,1:jp))
+		
+		! u_mid_yt = 0.5_wp*(u(1:ip,1:jp+1)+u(1:ip,0:jp)) &
+		! -(0.5_wp*dt/(redq_s(1:ip,0:jp)))* &
+		! 	(Uy(1:ip,1:jp+1)-Uy(1:ip,0:jp)) &
+		! +0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))* &
+		! 	(v(1:ip,1:jp+1)+v(1:ip,0:jp))
 
+		!3 v-phi, or u momentum equation (calculate mid-point values at 0.5*dt):
+		u_mid_xt(0:ip,:) = 0.5_wp*(u(1:ip+1,1:jp)+u(0:ip,1:jp)) &
+		-(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*u(0:ip,1:jp)* &
+			(u(1:ip+1,1:jp)-u(0:ip,1:jp)) &
+		+0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))* &
+			(v(1:ip+1,1:jp)+v(0:ip,1:jp))
+		
+		u_mid_yt = 0.5_wp*(u(1:ip,1:jp+1)+u(1:ip,0:jp)) &
+		-(0.5_wp*dt/(redq_s(1:ip,0:jp)))*v(1:ip,0:jp)* &
+			(u(1:ip,1:jp+1)-u(1:ip,0:jp)) &
+		+0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))* &
+			(v(1:ip,1:jp+1)+v(1:ip,0:jp))
 
-		! v-theta, or v momentum equation (calculate mid-point values at 0.5*dt):
-		Vx = uh*v
-		Vy = vh1*v
-		Vy2 = 0.5_wp*g*h**2
-		vh_mid_xt(0:ip,1:jp) = 0.5_wp*(vh(1:ip+1,1:jp)+vh(0:ip,1:jp)) &
-		  -(0.5_wp*dt/(0.5_wp*(dx(1:ip+1,1:jp)+dx(0:ip,1:jp))))*(Vx(1:ip+1,1:jp)-Vx(0:ip,1:jp)) &
-		  -0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))*(uh(1:ip+1,1:jp)+uh(0:ip,1:jp))
+		! !2 v-theta, or v momentum equation (calculate mid-point values at 0.5*dt):
+		! Vx = u*v
+		! Vy = v*v
+		! v_mid_xt(0:ip,1:jp) = 0.5_wp*(v(1:ip+1,1:jp)+v(0:ip,1:jp)) &
+		! 	-(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*(Vx(1:ip+1,1:jp)-Vx(0:ip,1:jp)) &
+		! 	-0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))*(u(1:ip+1,1:jp)+u(0:ip,1:jp))
 
-		vh_mid_yt(1:ip,0:jp) = 0.5_wp*(vh(1:ip,1:jp+1)+vh(1:ip,0:jp)) &
-		  -(0.5_wp*dt/(0.5_wp*(dy1(1:ip,1:jp+1)+dy1(1:ip,0:jp))))*(Vy(1:ip,1:jp+1)-Vy(1:ip,0:jp)) &
-		  -(0.5_wp*dt/(dy(1:ip,0:jp)))*(Vy2(1:ip,1:jp+1)-Vy2(1:ip,0:jp)) &
-		  -0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))*(uh(1:ip,1:jp+1)+uh(1:ip,0:jp))
+		! v_mid_yt(1:ip,0:jp) = 0.5_wp*(v(1:ip,1:jp+1)+v(1:ip,0:jp)) &
+		! 	-(0.5_wp*dt/(redq_s(1:ip,0:jp)))*(Vy(1:ip,1:jp+1)-Vy(1:ip,0:jp)) &
+		! 	-0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))*(u(1:ip,1:jp+1)+u(1:ip,0:jp))
+		
+		!3 v-theta, or v momentum equation (calculate mid-point values at 0.5*dt):
+		v_mid_xt(0:ip,1:jp) = 0.5_wp*(v(1:ip+1,1:jp)+v(0:ip,1:jp)) &
+			-(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*u(0:ip,1:jp)*(Vx(1:ip+1,1:jp)-Vx(0:ip,1:jp)) &
+			-0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))*(u(1:ip+1,1:jp)+u(0:ip,1:jp))
 
-! 		calculate mid-point value of cos (theta)
-! 		c_mid_yt=cos(0.5.*(THETA(:,2:end)+THETA(:,1:end-1)));
-! 
-! 
+		v_mid_yt(1:ip,0:jp) = 0.5_wp*(v(1:ip,1:jp+1)+v(1:ip,0:jp)) &
+			-(0.5_wp*dt/(redq_s(1:ip,0:jp)))*v(1:ip,0:jp)*(v(1:ip,1:jp+1)-v(1:ip,0:jp)) &
+			-0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))*(u(1:ip,1:jp+1)+u(1:ip,0:jp))
+
 		! Now use the mid-point values to predict the values at the next timestep
 		! continuity:
 		h_new = h(1:ip,1:jp) &
-		  - (dt/(0.5_wp*(dx(1:ip,1:jp)+dx(0:ip-1,1:jp))))*(uh_mid_xt(1:ip,1:jp)-uh_mid_xt(0:ip-1,1:jp)) &
-		  - (dt/(0.5_wp*(dy1(1:ip,1:jp)+dy1(1:ip,0:jp-1)))) * &
-		  (vh_mid_yt(1:ip,1:jp)*c_mid_yt(1:ip,1:jp)-vh_mid_yt(1:ip,0:jp-1)*c_mid_yt(1:ip,0:jp-1))
-
+		- (dt/(recqdp(0:ip-1,1:jp)))*(u_mid_xt(1:ip,1:jp)-u_mid_xt(0:ip-1,1:jp)) &
+		- (dt/(recqdq(1:ip,0:jp-1))) * &
+		(v_mid_yt(1:ip,1:jp)*cq_s(1:ip,1:jp)-v_mid_yt(1:ip,0:jp-1)*cq_s(1:ip,0:jp-1))
 
 		! u-momentum equation:
-		Ux_mid_xt = uh_mid_xt*uh_mid_xt/h_mid_xt + 0.5_wp*g*h_mid_xt**2
-		Uy_mid_yt = uh_mid_yt*vh_mid_yt/h_mid_yt*c_mid_yt
-		uh_new = uh(1:ip,1:jp) &
-		  - (dt/(0.5_wp*(dx(1:ip,1:jp)+dx(0:ip-1,1:jp))))*  (Ux_mid_xt(1:ip,1:jp)-Ux_mid_xt(0:ip-1,1:jp)) &
-		  - (dt/(0.5_wp*(dy1(1:ip,1:jp)+dy1(1:ip,0:jp-1))))*(Uy_mid_yt(1:ip,1:jp)-Uy_mid_yt(1:ip,0:jp-1))
-
+		Ux_mid_xt = u_mid_xt*u_mid_xt
+		Uy_mid_yt = u_mid_yt*v_mid_yt
+		u_new = u(1:ip,1:jp) &
+		- (dt/(recqdp(0:ip-1,1:jp)))*  (Ux_mid_xt(1:ip,1:jp)-Ux_mid_xt(0:ip-1,1:jp)) &
+		- (dt/(redq(1:ip,0:jp-1)))*(Uy_mid_yt(1:ip,1:jp)-Uy_mid_yt(1:ip,0:jp-1))
 
 		! v-momentum equation:
-		Vx_mid_xt = uh_mid_xt*vh_mid_xt/h_mid_xt
-		Vy_mid_yt = vh_mid_yt*vh_mid_yt/h_mid_yt*c_mid_yt
-		Vy_mid_yt2 = 0.5_wp*g*h_mid_yt**2
-		vh_new = vh(1:ip,1:jp) &
-		  - (dt/(0.5_wp*(dx(1:ip,1:jp)+dx(0:ip-1,1:jp))))*(Vx_mid_xt(1:ip,1:jp)-Vx_mid_xt(0:ip-1,1:jp)) &
-		  - (dt/(0.5_wp*(dy1(1:ip,1:jp)+dy1(1:ip,0:jp-1))))*(Vy_mid_yt(1:ip,1:jp)-Vy_mid_yt(1:ip,0:jp-1)) &
-		  - (dt/(dy(1:ip,0:jp-1) ))* &
-		  (Vy_mid_yt2(1:ip,1:jp)-Vy_mid_yt2(1:ip,0:jp-1))
-
+		Vx_mid_xt = u_mid_xt*v_mid_xt
+		Vy_mid_yt = v_mid_yt*v_mid_yt
+		v_new = v(1:ip,1:jp) &
+		- (dt/(recqdp(0:ip-1,1:jp)))*(Vx_mid_xt(1:ip,1:jp)-Vx_mid_xt(0:ip-1,1:jp)) &
+		- (dt/(redq(1:ip,0:jp-1)))*(Vy_mid_yt(1:ip,1:jp)-Vy_mid_yt(1:ip,0:jp-1))
 
 		! add on Coriolis and contribution of orography to pressure gradient:
-		uh_new=uh_new  +dt*.5_wp*(f_cor(1:ip,1:jp)*v(1:ip,1:jp) - &
-			g*(hs(2:ip+1,1:jp)-hs(0:ip-1,1:jp))/(2._wp*dx(1:ip,1:jp)))* &
-			(h(1:ip,1:jp)+h_new)
+		uv = u*v
+		u2 = u*u
+		u_new=u_new + dt*.5_wp*(f_cor(1:ip,1:jp)*v(1:ip,1:jp) - &
+			g*(hs(2:ip+1,1:jp)-hs(0:ip-1,1:jp))/(recqdp(1:ip,1:jp)+recqdp(0:ip-1,1:jp)) & 
+			- uv(1:ip,1:jp)*rect(1:ip,1:jp))
 
-		vh_new=vh_new  -dt*.5_wp*(f_cor(1:ip,1:jp)*u(1:ip,1:jp) + &
-			g*(hs(1:ip,2:jp+1)-hs(1:ip,0:jp-1))/(2._wp*dy1(1:ip,1:jp)))* &
-			(h(1:ip,1:jp)+h_new)
-
-! 		uh_new=uh_new  +dt*.5_wp*(f_cor(1:ip,1:jp)*(vh_mid_xt(1:ip,1:jp)+vh_mid_xt(0:ip-1,1:jp)) )
-! 
-! 		vh_new=vh_new  -dt*.5_wp*(f_cor(1:ip,1:jp)*(uh_mid_xt(1:ip,1:jp)+uh_mid_xt(0:ip-1,1:jp)) )
-
+		v_new=v_new - dt*.5_wp*(f_cor(1:ip,1:jp)*u(1:ip,1:jp) + &
+			g*(hs(1:ip,2:jp+1)-hs(1:ip,0:jp-1))/(redq(1:ip,1:jp)+redq(1:ip,0:jp-1)) & 
+			+ u2(1:ip,1:jp)*rect(1:ip,1:jp))
 
 		! re-calculate u and v.
-		u(1:ip,1:jp) = uh_new/(h_new)
-		v(1:ip,1:jp) = vh_new/h_new
+		u(1:ip,1:jp) = u_new
+		v(1:ip,1:jp) = v_new
 		h(1:ip,1:jp) = h_new
-																				
-! 		do j=1,jp
-! 			do i=1,ip
-! 				
-! 			
-! 			enddo
-! 		enddo																				
-
 
 	end subroutine lax_wendroff_sphere
 	
@@ -215,14 +230,14 @@
 																				
 		! local variables:
 		real(wp), dimension(1-o_halo:ip+o_halo,1-o_halo:jp+o_halo) :: & 
-					dy1, v1, h1, vh, uh, vh1, Ux, Uy, Vx, Vy, uv, u2
+					dy1, v1, h1, vh, uh, vh1, Ux, Uy, Vx, Vy, Vy2
 		real(wp), dimension(1:ip,1:jp) :: &
-									    u_new, v_new, h_new
+										uh_new, vh_new, h_new
 										
-		real(wp), dimension(0:ip,1:jp) :: h_mid_xt, u_mid_xt, Ux_mid_xt, Vx_mid_xt
-		real(wp), dimension(0:ip,1:jp) :: v_mid_xt
-		real(wp), dimension(1:ip,0:jp) :: h_mid_yt, u_mid_yt, v_mid_yt,  &
-		 									Uy_mid_yt, Vy_mid_yt
+		real(wp), dimension(0:ip,1:jp) :: h_mid_xt, uh_mid_xt, Ux_mid_xt, Vx_mid_xt
+		real(wp), dimension(0:ip,1:jp) :: vh_mid_xt
+		real(wp), dimension(1:ip,0:jp) :: h_mid_yt, uh_mid_yt, vh_mid_yt,  &
+												Uy_mid_yt, Vy_mid_yt, Vy_mid_yt2
 		integer(i4b) :: j, i
 			
 		
@@ -242,164 +257,77 @@
 		  -(0.5_wp*dt/(recqdq_s(1:ip,0:jp))) &
 		  *(vh1(1:ip,1:jp+1)-vh1(1:ip,0:jp))
 
-		! !1 v-phi, or u momentum equation (calculate mid-point values at 0.5*dt):
-		! Ux = uh*u + g*h**2*(0.5_wp)
-		! Uy = uh*v1
-		! uh_mid_xt(0:ip,:) = 0.5_wp*(uh(1:ip+1,1:jp)+uh(0:ip,1:jp)) &
-		!   -(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))* &
-		!   	(Ux(1:ip+1,1:jp)-Ux(0:ip,1:jp)) &
-		!   +0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))* &
-		!   	(vh(1:ip+1,1:jp)+vh(0:ip,1:jp))
+		! v-phi, or u momentum equation (calculate mid-point values at 0.5*dt):
+		Ux = uh*u + g*h**2*(0.5_wp)
+		Uy = uh*v1
+		uh_mid_xt(0:ip,:) = 0.5_wp*(uh(1:ip+1,1:jp)+uh(0:ip,1:jp)) &
+		  -(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))* &
+		  	(Ux(1:ip+1,1:jp)-Ux(0:ip,1:jp)) &
+		  +0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))* &
+		  	(vh(1:ip+1,1:jp)+vh(0:ip,1:jp))
 		
-		! uh_mid_yt = 0.5_wp*(uh(1:ip,1:jp+1)+uh(1:ip,0:jp)) &
-		!   -(0.5_wp*dt/(recqdq_s(1:ip,0:jp)))* &
-		!   	(Uy(1:ip,1:jp+1)-Uy(1:ip,0:jp)) &
-		!   +0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))* &
-		!   	(vh(1:ip,1:jp+1)+vh(1:ip,0:jp))
+		uh_mid_yt = 0.5_wp*(uh(1:ip,1:jp+1)+uh(1:ip,0:jp)) &
+		  -(0.5_wp*dt/(recqdq_s(1:ip,0:jp)))* &
+		  	(Uy(1:ip,1:jp+1)-Uy(1:ip,0:jp)) &
+		  +0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))* &
+		  	(vh(1:ip,1:jp+1)+vh(1:ip,0:jp))
 
-		! !2 v-phi, or u momentum equation (calculate mid-point values at 0.5*dt):
-		! Ux = u*u
-		! Uy = u*v
-		! u_mid_xt(0:ip,:) = 0.5_wp*(u(1:ip+1,1:jp)+u(0:ip,1:jp)) &
-		! -(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))* &
-		! 	(Ux(1:ip+1,1:jp)-Ux(0:ip,1:jp)) &
-		! +0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))* &
-		! 	(v(1:ip+1,1:jp)+v(0:ip,1:jp))
-		
-		! u_mid_yt = 0.5_wp*(u(1:ip,1:jp+1)+u(1:ip,0:jp)) &
-		! -(0.5_wp*dt/(redq_s(1:ip,0:jp)))* &
-		! 	(Uy(1:ip,1:jp+1)-Uy(1:ip,0:jp)) &
-		! +0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))* &
-		! 	(v(1:ip,1:jp+1)+v(1:ip,0:jp))
+		! v-theta, or v momentum equation (calculate mid-point values at 0.5*dt):
+		Vx = uh*v
+		Vy = vh1*v
+		Vy2 = 0.5_wp*g*h**2
+		vh_mid_xt(0:ip,1:jp) = 0.5_wp*(vh(1:ip+1,1:jp)+vh(0:ip,1:jp)) &
+		  -(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*(Vx(1:ip+1,1:jp)-Vx(0:ip,1:jp)) &
+		  -0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))*(uh(1:ip+1,1:jp)+uh(0:ip,1:jp))
 
-		!3 v-phi, or u momentum equation (calculate mid-point values at 0.5*dt):
-		Ux = u
-		Uy = u
-		u_mid_xt(0:ip,:) = 0.5_wp*(u(1:ip+1,1:jp)+u(0:ip,1:jp)) &
-		-(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*u(0:ip,1:jp)* &
-			(Ux(1:ip+1,1:jp)-Ux(0:ip,1:jp)) &
-		+0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))* &
-			(v(1:ip+1,1:jp)+v(0:ip,1:jp))
-		
-		u_mid_yt = 0.5_wp*(u(1:ip,1:jp+1)+u(1:ip,0:jp)) &
-		-(0.5_wp*dt/(redq_s(1:ip,0:jp)))*v(1:ip,0:jp)* &
-			(Uy(1:ip,1:jp+1)-Uy(1:ip,0:jp)) &
-		+0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))* &
-			(v(1:ip,1:jp+1)+v(1:ip,0:jp))
+		vh_mid_yt(1:ip,0:jp) = 0.5_wp*(vh(1:ip,1:jp+1)+vh(1:ip,0:jp)) &
+		  -(0.5_wp*dt/(recqdq_s(1:ip,0:jp)))*(Vy(1:ip,1:jp+1)-Vy(1:ip,0:jp)) &
+		  -(0.5_wp*dt/(redq_s(1:ip,0:jp)))*(Vy2(1:ip,1:jp+1)-Vy2(1:ip,0:jp)) &
+		  -0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))*(uh(1:ip,1:jp+1)+uh(1:ip,0:jp))
 
+		! calculate mid-point value of cos (theta)
+		! c_mid_yt=cos(0.5.*(THETA(:,2:end)+THETA(:,1:end-1)));
 
-		! !1 v-theta, or v momentum equation (calculate mid-point values at 0.5*dt):
-		! Vx = uh*v
-		! Vy = vh1*v
-		! Vy2 = 0.5_wp*g*h**2
-		! vh_mid_xt(0:ip,1:jp) = 0.5_wp*(vh(1:ip+1,1:jp)+vh(0:ip,1:jp)) &
-		!   -(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*(Vx(1:ip+1,1:jp)-Vx(0:ip,1:jp)) &
-		!   -0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))*(uh(1:ip+1,1:jp)+uh(0:ip,1:jp))
-
-		! vh_mid_yt(1:ip,0:jp) = 0.5_wp*(vh(1:ip,1:jp+1)+vh(1:ip,0:jp)) &
-		!   -(0.5_wp*dt/(recqdq_s(1:ip,0:jp)))*(Vy(1:ip,1:jp+1)-Vy(1:ip,0:jp)) &
-		!   -(0.5_wp*dt/(redq_s(1:ip,0:jp)))*(Vy2(1:ip,1:jp+1)-Vy2(1:ip,0:jp)) &
-		!   -0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))*(uh(1:ip,1:jp+1)+uh(1:ip,0:jp))
-
-		! !2 v-theta, or v momentum equation (calculate mid-point values at 0.5*dt):
-		! Vx = u*v
-		! Vy = v*v
-		! v_mid_xt(0:ip,1:jp) = 0.5_wp*(v(1:ip+1,1:jp)+v(0:ip,1:jp)) &
-		! 	-(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*(Vx(1:ip+1,1:jp)-Vx(0:ip,1:jp)) &
-		! 	-0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))*(u(1:ip+1,1:jp)+u(0:ip,1:jp))
-
-		! v_mid_yt(1:ip,0:jp) = 0.5_wp*(v(1:ip,1:jp+1)+v(1:ip,0:jp)) &
-		! 	-(0.5_wp*dt/(redq_s(1:ip,0:jp)))*(Vy(1:ip,1:jp+1)-Vy(1:ip,0:jp)) &
-		! 	-0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))*(u(1:ip,1:jp+1)+u(1:ip,0:jp))
-		
-		!3 v-theta, or v momentum equation (calculate mid-point values at 0.5*dt):
-		Vx = v
-		Vy = v
-		v_mid_xt(0:ip,1:jp) = 0.5_wp*(v(1:ip+1,1:jp)+v(0:ip,1:jp)) &
-			-(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*u(0:ip,1:jp)*(Vx(1:ip+1,1:jp)-Vx(0:ip,1:jp)) &
-			-0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))*(u(1:ip+1,1:jp)+u(0:ip,1:jp))
-
-		v_mid_yt(1:ip,0:jp) = 0.5_wp*(v(1:ip,1:jp+1)+v(1:ip,0:jp)) &
-			-(0.5_wp*dt/(redq_s(1:ip,0:jp)))*v(1:ip,0:jp)*(Vy(1:ip,1:jp+1)-Vy(1:ip,0:jp)) &
-			-0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))*(u(1:ip,1:jp+1)+u(1:ip,0:jp))
-
-! 		calculate mid-point value of cos (theta)
-! 		c_mid_yt=cos(0.5.*(THETA(:,2:end)+THETA(:,1:end-1)));
-! 
-! 
 		! Now use the mid-point values to predict the values at the next timestep
 		! continuity:
 		h_new = h(1:ip,1:jp) &
-		  - (dt/(recqdp(0:ip-1,1:jp)))*(u_mid_xt(1:ip,1:jp)-u_mid_xt(0:ip-1,1:jp)) &
+		  - (dt/(recqdp(0:ip-1,1:jp)))*(uh_mid_xt(1:ip,1:jp)-uh_mid_xt(0:ip-1,1:jp)) &
 		  - (dt/(recqdq(1:ip,0:jp-1))) * &
-		  (v_mid_yt(1:ip,1:jp)*cq_s(1:ip,1:jp)-v_mid_yt(1:ip,0:jp-1)*cq_s(1:ip,0:jp-1))
+		  (vh_mid_yt(1:ip,1:jp)*cq_s(1:ip,1:jp)-vh_mid_yt(1:ip,0:jp-1)*cq_s(1:ip,0:jp-1))
 
-
-		! ! u-momentum equation:
-		! Ux_mid_xt = uh_mid_xt*uh_mid_xt/h_mid_xt + 0.5_wp*g*h_mid_xt**2
-		! Uy_mid_yt = uh_mid_yt*vh_mid_yt/h_mid_yt*cq_s(1:ip,0:jp)
-		! uh_new = uh(1:ip,1:jp) &
-		!   - (dt/(recqdp(0:ip-1,1:jp)))*  (Ux_mid_xt(1:ip,1:jp)-Ux_mid_xt(0:ip-1,1:jp)) &
-		!   - (dt/(recqdq(1:ip,0:jp-1)))*(Uy_mid_yt(1:ip,1:jp)-Uy_mid_yt(1:ip,0:jp-1))
 
 		! u-momentum equation:
-		Ux_mid_xt = u_mid_xt*u_mid_xt
-		Uy_mid_yt = u_mid_yt*v_mid_yt
-		u_new = u(1:ip,1:jp) &
+		Ux_mid_xt = uh_mid_xt*uh_mid_xt/h_mid_xt + 0.5_wp*g*h_mid_xt**2
+		Uy_mid_yt = uh_mid_yt*vh_mid_yt/h_mid_yt*cq_s(1:ip,0:jp)
+		uh_new = uh(1:ip,1:jp) &
 		  - (dt/(recqdp(0:ip-1,1:jp)))*  (Ux_mid_xt(1:ip,1:jp)-Ux_mid_xt(0:ip-1,1:jp)) &
-		  - (dt/(redq(1:ip,0:jp-1)))*(Uy_mid_yt(1:ip,1:jp)-Uy_mid_yt(1:ip,0:jp-1))
-
-		! v-momentum equation:
-		! Vx_mid_xt = uh_mid_xt*vh_mid_xt/h_mid_xt
-		! Vy_mid_yt = vh_mid_yt*vh_mid_yt/h_mid_yt*cq_s(1:ip,0:jp)
-		! Vy_mid_yt2 = 0.5_wp*g*h_mid_yt**2
-		! v_new = v(1:ip,1:jp) &
-		!   - (dt/(recqdp(0:ip-1,1:jp)))*(Vx_mid_xt(1:ip,1:jp)-Vx_mid_xt(0:ip-1,1:jp)) &
-		!   - (dt/(recqdq(1:ip,0:jp-1)))*(Vy_mid_yt(1:ip,1:jp)-Vy_mid_yt(1:ip,0:jp-1)) &
-		!   - (dt/(redq(1:ip,0:jp-1) ))* &
-		!   (Vy_mid_yt2(1:ip,1:jp)-Vy_mid_yt2(1:ip,0:jp-1))
+		  - (dt/(recqdq(1:ip,0:jp-1)))*(Uy_mid_yt(1:ip,1:jp)-Uy_mid_yt(1:ip,0:jp-1))
 
 
 		! v-momentum equation:
-		Vx_mid_xt = u_mid_xt*v_mid_xt
-		Vy_mid_yt = v_mid_yt*v_mid_yt
-		v_new = v(1:ip,1:jp) &
+		Vx_mid_xt = uh_mid_xt*vh_mid_xt/h_mid_xt
+		Vy_mid_yt = vh_mid_yt*vh_mid_yt/h_mid_yt*cq_s(1:ip,0:jp)
+		Vy_mid_yt2 = 0.5_wp*g*h_mid_yt**2
+		vh_new = vh(1:ip,1:jp) &
 		  - (dt/(recqdp(0:ip-1,1:jp)))*(Vx_mid_xt(1:ip,1:jp)-Vx_mid_xt(0:ip-1,1:jp)) &
-		  - (dt/(redq(1:ip,0:jp-1)))*(Vy_mid_yt(1:ip,1:jp)-Vy_mid_yt(1:ip,0:jp-1))
+		  - (dt/(recqdq(1:ip,0:jp-1)))*(Vy_mid_yt(1:ip,1:jp)-Vy_mid_yt(1:ip,0:jp-1)) &
+		  - (dt/(redq(1:ip,0:jp-1) ))* &
+		  (Vy_mid_yt2(1:ip,1:jp)-Vy_mid_yt2(1:ip,0:jp-1))
 
 
-		! ! add on Coriolis and contribution of orography to pressure gradient:
-		! uh_new=uh_new  +dt*.5_wp*(f_cor(1:ip,1:jp)*v(1:ip,1:jp) - &
-		!   g*(hs(2:ip+1,1:jp)-hs(0:ip-1,1:jp))/(recqdp(1:ip,1:jp)+recqdp(0:ip-1,1:jp)))* &
-		!   (h(1:ip,1:jp)+h_new)
-
-	  	! vh_new=vh_new  -dt*.5_wp*(f_cor(1:ip,1:jp)*u(1:ip,1:jp) + &
-		!   g*(hs(1:ip,2:jp+1)-hs(1:ip,0:jp-1))/(redq(1:ip,1:jp)+redq(1:ip,0:jp-1)))* &
-		!   (h(1:ip,1:jp)+h_new)
-
-		
 		! add on Coriolis and contribution of orography to pressure gradient:
-		uv = u*v
-		u2 = u*u
-		u_new=u_new + dt*.5_wp*(f_cor(1:ip,1:jp)*v(1:ip,1:jp) - &
-			g*(hs(2:ip+1,1:jp)-hs(0:ip-1,1:jp))/(recqdp(1:ip,1:jp)+recqdp(0:ip-1,1:jp)) & 
-			- uv(1:ip,1:jp)*rect(1:ip,1:jp))
+		uh_new=uh_new  +dt*.5_wp*(f_cor(1:ip,1:jp)*v(1:ip,1:jp) - &
+			g*(hs(2:ip+1,1:jp)-hs(0:ip-1,1:jp))/(recqdp(1:ip,1:jp)+recqdp(0:ip-1,1:jp)))* &
+			(h(1:ip,1:jp)+h_new)
 
-		v_new=v_new - dt*.5_wp*(f_cor(1:ip,1:jp)*u(1:ip,1:jp) + &
-			g*(hs(1:ip,2:jp+1)-hs(1:ip,0:jp-1))/(redq(1:ip,1:jp)+redq(1:ip,0:jp-1)) & 
-			+ u2(1:ip,1:jp)*rect(1:ip,1:jp))
-
-
-		! ! re-calculate u and v.
-		! u(1:ip,1:jp) = uh_new/(h_new)
-		! v(1:ip,1:jp) = vh_new/h_new
-		! h(1:ip,1:jp) = h_new
+		vh_new=vh_new  -dt*.5_wp*(f_cor(1:ip,1:jp)*u(1:ip,1:jp) + &
+			g*(hs(1:ip,2:jp+1)-hs(1:ip,0:jp-1))/(redq(1:ip,1:jp)+redq(1:ip,0:jp-1)))* &
+			(h(1:ip,1:jp)+h_new)
 
 		! re-calculate u and v.
-		u(1:ip,1:jp) = u_new
-		v(1:ip,1:jp) = v_new
+		u(1:ip,1:jp) = uh_new/(h_new)
+		v(1:ip,1:jp) = vh_new/h_new
 		h(1:ip,1:jp) = h_new
-
 
 	end subroutine lax_wendroff_ll
 

--- a/src/advection.f90
+++ b/src/advection.f90
@@ -140,23 +140,23 @@
 		! Now use the mid-point values to predict the values at the next timestep
 		! continuity:
 		h_new = h(1:ip,1:jp) &
-		- (dt/(recqdp(0:ip-1,1:jp)))*(u_mid_xt(1:ip,1:jp)-u_mid_xt(0:ip-1,1:jp)) &
-		- (dt/(recqdq(1:ip,0:jp-1))) * &
-		(v_mid_yt(1:ip,1:jp)*cq_s(1:ip,1:jp)-v_mid_yt(1:ip,0:jp-1)*cq_s(1:ip,0:jp-1))
+			- (dt/(recqdp(0:ip-1,1:jp)))*h(1:ip,1:jp)*(u_mid_xt(1:ip,1:jp)-u_mid_xt(0:ip-1,1:jp)) &
+			- (dt/(recqdq(1:ip,0:jp-1))) * &
+			h(1:ip,1:jp)*(v_mid_yt(1:ip,1:jp)*cq_s(1:ip,1:jp)-v_mid_yt(1:ip,0:jp-1)*cq_s(1:ip,0:jp-1))
 
 		! u-momentum equation:
 		Ux_mid_xt = u_mid_xt*u_mid_xt
 		Uy_mid_yt = u_mid_yt*v_mid_yt
 		u_new = u(1:ip,1:jp) &
-		- (dt/(recqdp(0:ip-1,1:jp)))*  (Ux_mid_xt(1:ip,1:jp)-Ux_mid_xt(0:ip-1,1:jp)) &
-		- (dt/(redq(1:ip,0:jp-1)))*(Uy_mid_yt(1:ip,1:jp)-Uy_mid_yt(1:ip,0:jp-1))
+			- (dt/(recqdp(0:ip-1,1:jp)))*(Ux_mid_xt(1:ip,1:jp)-Ux_mid_xt(0:ip-1,1:jp)) &
+			- (dt/(redq(1:ip,0:jp-1)))*(Uy_mid_yt(1:ip,1:jp)-Uy_mid_yt(1:ip,0:jp-1))
 
 		! v-momentum equation:
 		Vx_mid_xt = u_mid_xt*v_mid_xt
 		Vy_mid_yt = v_mid_yt*v_mid_yt
 		v_new = v(1:ip,1:jp) &
-		- (dt/(recqdp(0:ip-1,1:jp)))*(Vx_mid_xt(1:ip,1:jp)-Vx_mid_xt(0:ip-1,1:jp)) &
-		- (dt/(redq(1:ip,0:jp-1)))*(Vy_mid_yt(1:ip,1:jp)-Vy_mid_yt(1:ip,0:jp-1))
+			- (dt/(recqdp(0:ip-1,1:jp)))*(Vx_mid_xt(1:ip,1:jp)-Vx_mid_xt(0:ip-1,1:jp)) &
+			- (dt/(redq(1:ip,0:jp-1)))*(Vy_mid_yt(1:ip,1:jp)-Vy_mid_yt(1:ip,0:jp-1))
 
 		! add on Coriolis and contribution of orography to pressure gradient:
 		uv = u*v

--- a/src/advection.f90
+++ b/src/advection.f90
@@ -188,13 +188,15 @@
 	!>@param[in] recqdq_s - for efficiency
 	!>@param[in] redq_s - for efficiency
 	!>@param[in] redq - for efficiency
+	!>@param[in] rect - for efficiency
+	!>@param[in] rect_s - for efficiency
 	!>@param[in] cq - for efficiency
 	!>@param[in] cq_s - for efficiency
 	!>solves the 1-d advection equation:
 	!>\f$ \frac{\partial \psi}{\partial t} + \frac{\partial u \psi}{\partial x} = 0 \f$
     subroutine lax_wendroff_ll(ip,jp,o_halo,dt,g,u,v,h,hs,re,&
     		theta,thetan,dtheta,dthetan, phi, phin, dphi, dphin, f_cor, &
-    		recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, cq, cq_s)
+    		recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, rect, rect_s, cq, cq_s)
 
 		use numerics_type
 		implicit none
@@ -202,8 +204,8 @@
 		real(wp), intent(in) :: dt, g, re
 		real(wp), intent(in), dimension(1-o_halo:ip+o_halo,1-o_halo:jp+o_halo) :: &
 																		hs, f_cor, &
-    				recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, &
-    				cq, cq_s
+    				recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, rect, &
+    				rect_s, cq, cq_s
 		real(wp), dimension(1-o_halo:jp+o_halo), intent(in) :: &
 											theta,thetan, dtheta, dthetan
 		real(wp), dimension(1-o_halo:ip+o_halo), intent(in) :: &											
@@ -213,14 +215,14 @@
 																				
 		! local variables:
 		real(wp), dimension(1-o_halo:ip+o_halo,1-o_halo:jp+o_halo) :: & 
-					dy1, v1, h1, vh, uh, vh1, Ux, Uy, Vx, Vy, Vy2
+					dy1, v1, h1, vh, uh, vh1, Ux, Uy, Vx, Vy, uv, u2
 		real(wp), dimension(1:ip,1:jp) :: &
-									    uh_new, vh_new, h_new
+									    u_new, v_new, h_new
 										
-		real(wp), dimension(0:ip,1:jp) :: h_mid_xt, uh_mid_xt, Ux_mid_xt, Vx_mid_xt
-		real(wp), dimension(0:ip,1:jp) :: vh_mid_xt
-		real(wp), dimension(1:ip,0:jp) :: h_mid_yt, uh_mid_yt, vh_mid_yt,  &
-		 									Uy_mid_yt, Vy_mid_yt, Vy_mid_yt2
+		real(wp), dimension(0:ip,1:jp) :: h_mid_xt, u_mid_xt, Ux_mid_xt, Vx_mid_xt
+		real(wp), dimension(0:ip,1:jp) :: v_mid_xt
+		real(wp), dimension(1:ip,0:jp) :: h_mid_yt, u_mid_yt, v_mid_yt,  &
+		 									Uy_mid_yt, Vy_mid_yt
 		integer(i4b) :: j, i
 			
 		
@@ -240,35 +242,86 @@
 		  -(0.5_wp*dt/(recqdq_s(1:ip,0:jp))) &
 		  *(vh1(1:ip,1:jp+1)-vh1(1:ip,0:jp))
 
-		! v-phi, or u momentum equation (calculate mid-point values at 0.5*dt):
-		Ux = uh*u + g*h**2*(0.5_wp)
-		Uy = uh*v1
-		uh_mid_xt(0:ip,:) = 0.5_wp*(uh(1:ip+1,1:jp)+uh(0:ip,1:jp)) &
-		  -(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))* &
-		  	(Ux(1:ip+1,1:jp)-Ux(0:ip,1:jp)) &
-		  +0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))* &
-		  	(vh(1:ip+1,1:jp)+vh(0:ip,1:jp))
+		! !1 v-phi, or u momentum equation (calculate mid-point values at 0.5*dt):
+		! Ux = uh*u + g*h**2*(0.5_wp)
+		! Uy = uh*v1
+		! uh_mid_xt(0:ip,:) = 0.5_wp*(uh(1:ip+1,1:jp)+uh(0:ip,1:jp)) &
+		!   -(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))* &
+		!   	(Ux(1:ip+1,1:jp)-Ux(0:ip,1:jp)) &
+		!   +0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))* &
+		!   	(vh(1:ip+1,1:jp)+vh(0:ip,1:jp))
 		
-		uh_mid_yt = 0.5_wp*(uh(1:ip,1:jp+1)+uh(1:ip,0:jp)) &
-		  -(0.5_wp*dt/(recqdq_s(1:ip,0:jp)))* &
-		  	(Uy(1:ip,1:jp+1)-Uy(1:ip,0:jp)) &
-		  +0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))* &
-		  	(vh(1:ip,1:jp+1)+vh(1:ip,0:jp))
+		! uh_mid_yt = 0.5_wp*(uh(1:ip,1:jp+1)+uh(1:ip,0:jp)) &
+		!   -(0.5_wp*dt/(recqdq_s(1:ip,0:jp)))* &
+		!   	(Uy(1:ip,1:jp+1)-Uy(1:ip,0:jp)) &
+		!   +0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))* &
+		!   	(vh(1:ip,1:jp+1)+vh(1:ip,0:jp))
+
+		! !2 v-phi, or u momentum equation (calculate mid-point values at 0.5*dt):
+		! Ux = u*u
+		! Uy = u*v
+		! u_mid_xt(0:ip,:) = 0.5_wp*(u(1:ip+1,1:jp)+u(0:ip,1:jp)) &
+		! -(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))* &
+		! 	(Ux(1:ip+1,1:jp)-Ux(0:ip,1:jp)) &
+		! +0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))* &
+		! 	(v(1:ip+1,1:jp)+v(0:ip,1:jp))
+		
+		! u_mid_yt = 0.5_wp*(u(1:ip,1:jp+1)+u(1:ip,0:jp)) &
+		! -(0.5_wp*dt/(redq_s(1:ip,0:jp)))* &
+		! 	(Uy(1:ip,1:jp+1)-Uy(1:ip,0:jp)) &
+		! +0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))* &
+		! 	(v(1:ip,1:jp+1)+v(1:ip,0:jp))
+
+		!3 v-phi, or u momentum equation (calculate mid-point values at 0.5*dt):
+		Ux = u
+		Uy = u
+		u_mid_xt(0:ip,:) = 0.5_wp*(u(1:ip+1,1:jp)+u(0:ip,1:jp)) &
+		-(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*u(0:ip,1:jp)* &
+			(Ux(1:ip+1,1:jp)-Ux(0:ip,1:jp)) &
+		+0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))* &
+			(v(1:ip+1,1:jp)+v(0:ip,1:jp))
+		
+		u_mid_yt = 0.5_wp*(u(1:ip,1:jp+1)+u(1:ip,0:jp)) &
+		-(0.5_wp*dt/(redq_s(1:ip,0:jp)))*v(1:ip,0:jp)* &
+			(Uy(1:ip,1:jp+1)-Uy(1:ip,0:jp)) &
+		+0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))* &
+			(v(1:ip,1:jp+1)+v(1:ip,0:jp))
 
 
+		! !1 v-theta, or v momentum equation (calculate mid-point values at 0.5*dt):
+		! Vx = uh*v
+		! Vy = vh1*v
+		! Vy2 = 0.5_wp*g*h**2
+		! vh_mid_xt(0:ip,1:jp) = 0.5_wp*(vh(1:ip+1,1:jp)+vh(0:ip,1:jp)) &
+		!   -(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*(Vx(1:ip+1,1:jp)-Vx(0:ip,1:jp)) &
+		!   -0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))*(uh(1:ip+1,1:jp)+uh(0:ip,1:jp))
 
-		! v-theta, or v momentum equation (calculate mid-point values at 0.5*dt):
-		Vx = uh*v
-		Vy = vh1*v
-		Vy2 = 0.5_wp*g*h**2
-		vh_mid_xt(0:ip,1:jp) = 0.5_wp*(vh(1:ip+1,1:jp)+vh(0:ip,1:jp)) &
-		  -(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*(Vx(1:ip+1,1:jp)-Vx(0:ip,1:jp)) &
-		  -0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))*(uh(1:ip+1,1:jp)+uh(0:ip,1:jp))
+		! vh_mid_yt(1:ip,0:jp) = 0.5_wp*(vh(1:ip,1:jp+1)+vh(1:ip,0:jp)) &
+		!   -(0.5_wp*dt/(recqdq_s(1:ip,0:jp)))*(Vy(1:ip,1:jp+1)-Vy(1:ip,0:jp)) &
+		!   -(0.5_wp*dt/(redq_s(1:ip,0:jp)))*(Vy2(1:ip,1:jp+1)-Vy2(1:ip,0:jp)) &
+		!   -0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))*(uh(1:ip,1:jp+1)+uh(1:ip,0:jp))
 
-		vh_mid_yt(1:ip,0:jp) = 0.5_wp*(vh(1:ip,1:jp+1)+vh(1:ip,0:jp)) &
-		  -(0.5_wp*dt/(recqdq_s(1:ip,0:jp)))*(Vy(1:ip,1:jp+1)-Vy(1:ip,0:jp)) &
-		  -(0.5_wp*dt/(redq_s(1:ip,0:jp)))*(Vy2(1:ip,1:jp+1)-Vy2(1:ip,0:jp)) &
-		  -0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))*(uh(1:ip,1:jp+1)+uh(1:ip,0:jp))
+		! !2 v-theta, or v momentum equation (calculate mid-point values at 0.5*dt):
+		! Vx = u*v
+		! Vy = v*v
+		! v_mid_xt(0:ip,1:jp) = 0.5_wp*(v(1:ip+1,1:jp)+v(0:ip,1:jp)) &
+		! 	-(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*(Vx(1:ip+1,1:jp)-Vx(0:ip,1:jp)) &
+		! 	-0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))*(u(1:ip+1,1:jp)+u(0:ip,1:jp))
+
+		! v_mid_yt(1:ip,0:jp) = 0.5_wp*(v(1:ip,1:jp+1)+v(1:ip,0:jp)) &
+		! 	-(0.5_wp*dt/(redq_s(1:ip,0:jp)))*(Vy(1:ip,1:jp+1)-Vy(1:ip,0:jp)) &
+		! 	-0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))*(u(1:ip,1:jp+1)+u(1:ip,0:jp))
+		
+		!3 v-theta, or v momentum equation (calculate mid-point values at 0.5*dt):
+		Vx = v
+		Vy = v
+		v_mid_xt(0:ip,1:jp) = 0.5_wp*(v(1:ip+1,1:jp)+v(0:ip,1:jp)) &
+			-(0.5_wp*dt/(recqdp_s(0:ip,1:jp)))*u(0:ip,1:jp)*(Vx(1:ip+1,1:jp)-Vx(0:ip,1:jp)) &
+			-0.125_wp*dt*(f_cor(1:ip+1,1:jp)+f_cor(0:ip,1:jp))*(u(1:ip+1,1:jp)+u(0:ip,1:jp))
+
+		v_mid_yt(1:ip,0:jp) = 0.5_wp*(v(1:ip,1:jp+1)+v(1:ip,0:jp)) &
+			-(0.5_wp*dt/(redq_s(1:ip,0:jp)))*v(1:ip,0:jp)*(Vy(1:ip,1:jp+1)-Vy(1:ip,0:jp)) &
+			-0.125_wp*dt*(f_cor(1:ip,1:jp+1)+f_cor(1:ip,0:jp))*(u(1:ip,1:jp+1)+u(1:ip,0:jp))
 
 ! 		calculate mid-point value of cos (theta)
 ! 		c_mid_yt=cos(0.5.*(THETA(:,2:end)+THETA(:,1:end-1)));
@@ -277,44 +330,74 @@
 		! Now use the mid-point values to predict the values at the next timestep
 		! continuity:
 		h_new = h(1:ip,1:jp) &
-		  - (dt/(recqdp(0:ip-1,1:jp)))*(uh_mid_xt(1:ip,1:jp)-uh_mid_xt(0:ip-1,1:jp)) &
+		  - (dt/(recqdp(0:ip-1,1:jp)))*(u_mid_xt(1:ip,1:jp)-u_mid_xt(0:ip-1,1:jp)) &
 		  - (dt/(recqdq(1:ip,0:jp-1))) * &
-		  (vh_mid_yt(1:ip,1:jp)*cq_s(1:ip,1:jp)-vh_mid_yt(1:ip,0:jp-1)*cq_s(1:ip,0:jp-1))
+		  (v_mid_yt(1:ip,1:jp)*cq_s(1:ip,1:jp)-v_mid_yt(1:ip,0:jp-1)*cq_s(1:ip,0:jp-1))
 
+
+		! ! u-momentum equation:
+		! Ux_mid_xt = uh_mid_xt*uh_mid_xt/h_mid_xt + 0.5_wp*g*h_mid_xt**2
+		! Uy_mid_yt = uh_mid_yt*vh_mid_yt/h_mid_yt*cq_s(1:ip,0:jp)
+		! uh_new = uh(1:ip,1:jp) &
+		!   - (dt/(recqdp(0:ip-1,1:jp)))*  (Ux_mid_xt(1:ip,1:jp)-Ux_mid_xt(0:ip-1,1:jp)) &
+		!   - (dt/(recqdq(1:ip,0:jp-1)))*(Uy_mid_yt(1:ip,1:jp)-Uy_mid_yt(1:ip,0:jp-1))
 
 		! u-momentum equation:
-		Ux_mid_xt = uh_mid_xt*uh_mid_xt/h_mid_xt + 0.5_wp*g*h_mid_xt**2
-		Uy_mid_yt = uh_mid_yt*vh_mid_yt/h_mid_yt*cq_s(1:ip,0:jp)
-		uh_new = uh(1:ip,1:jp) &
+		Ux_mid_xt = u_mid_xt*u_mid_xt
+		Uy_mid_yt = u_mid_yt*v_mid_yt
+		u_new = u(1:ip,1:jp) &
 		  - (dt/(recqdp(0:ip-1,1:jp)))*  (Ux_mid_xt(1:ip,1:jp)-Ux_mid_xt(0:ip-1,1:jp)) &
-		  - (dt/(recqdq(1:ip,0:jp-1)))*(Uy_mid_yt(1:ip,1:jp)-Uy_mid_yt(1:ip,0:jp-1))
+		  - (dt/(redq(1:ip,0:jp-1)))*(Uy_mid_yt(1:ip,1:jp)-Uy_mid_yt(1:ip,0:jp-1))
+
+		! v-momentum equation:
+		! Vx_mid_xt = uh_mid_xt*vh_mid_xt/h_mid_xt
+		! Vy_mid_yt = vh_mid_yt*vh_mid_yt/h_mid_yt*cq_s(1:ip,0:jp)
+		! Vy_mid_yt2 = 0.5_wp*g*h_mid_yt**2
+		! v_new = v(1:ip,1:jp) &
+		!   - (dt/(recqdp(0:ip-1,1:jp)))*(Vx_mid_xt(1:ip,1:jp)-Vx_mid_xt(0:ip-1,1:jp)) &
+		!   - (dt/(recqdq(1:ip,0:jp-1)))*(Vy_mid_yt(1:ip,1:jp)-Vy_mid_yt(1:ip,0:jp-1)) &
+		!   - (dt/(redq(1:ip,0:jp-1) ))* &
+		!   (Vy_mid_yt2(1:ip,1:jp)-Vy_mid_yt2(1:ip,0:jp-1))
 
 
 		! v-momentum equation:
-		Vx_mid_xt = uh_mid_xt*vh_mid_xt/h_mid_xt
-		Vy_mid_yt = vh_mid_yt*vh_mid_yt/h_mid_yt*cq_s(1:ip,0:jp)
-		Vy_mid_yt2 = 0.5_wp*g*h_mid_yt**2
-		vh_new = vh(1:ip,1:jp) &
+		Vx_mid_xt = u_mid_xt*v_mid_xt
+		Vy_mid_yt = v_mid_yt*v_mid_yt
+		v_new = v(1:ip,1:jp) &
 		  - (dt/(recqdp(0:ip-1,1:jp)))*(Vx_mid_xt(1:ip,1:jp)-Vx_mid_xt(0:ip-1,1:jp)) &
-		  - (dt/(recqdq(1:ip,0:jp-1)))*(Vy_mid_yt(1:ip,1:jp)-Vy_mid_yt(1:ip,0:jp-1)) &
-		  - (dt/(redq(1:ip,0:jp-1) ))* &
-		  (Vy_mid_yt2(1:ip,1:jp)-Vy_mid_yt2(1:ip,0:jp-1))
+		  - (dt/(redq(1:ip,0:jp-1)))*(Vy_mid_yt(1:ip,1:jp)-Vy_mid_yt(1:ip,0:jp-1))
 
 
+		! ! add on Coriolis and contribution of orography to pressure gradient:
+		! uh_new=uh_new  +dt*.5_wp*(f_cor(1:ip,1:jp)*v(1:ip,1:jp) - &
+		!   g*(hs(2:ip+1,1:jp)-hs(0:ip-1,1:jp))/(recqdp(1:ip,1:jp)+recqdp(0:ip-1,1:jp)))* &
+		!   (h(1:ip,1:jp)+h_new)
+
+	  	! vh_new=vh_new  -dt*.5_wp*(f_cor(1:ip,1:jp)*u(1:ip,1:jp) + &
+		!   g*(hs(1:ip,2:jp+1)-hs(1:ip,0:jp-1))/(redq(1:ip,1:jp)+redq(1:ip,0:jp-1)))* &
+		!   (h(1:ip,1:jp)+h_new)
+
+		
 		! add on Coriolis and contribution of orography to pressure gradient:
-		uh_new=uh_new  +dt*.5_wp*(f_cor(1:ip,1:jp)*v(1:ip,1:jp) - &
-			g*(hs(2:ip+1,1:jp)-hs(0:ip-1,1:jp))/(recqdp(1:ip,1:jp)+recqdp(0:ip-1,1:jp)))* &
-			(h(1:ip,1:jp)+h_new)
+		uv = u*v
+		u2 = u*u
+		u_new=u_new + dt*.5_wp*(f_cor(1:ip,1:jp)*v(1:ip,1:jp) - &
+			g*(hs(2:ip+1,1:jp)-hs(0:ip-1,1:jp))/(recqdp(1:ip,1:jp)+recqdp(0:ip-1,1:jp)) & 
+			- uv(1:ip,1:jp)*rect(1:ip,1:jp))
 
-		vh_new=vh_new  -dt*.5_wp*(f_cor(1:ip,1:jp)*u(1:ip,1:jp) + &
-			g*(hs(1:ip,2:jp+1)-hs(1:ip,0:jp-1))/(redq(1:ip,1:jp)+redq(1:ip,0:jp-1)))* &
-			(h(1:ip,1:jp)+h_new)
+		v_new=v_new - dt*.5_wp*(f_cor(1:ip,1:jp)*u(1:ip,1:jp) + &
+			g*(hs(1:ip,2:jp+1)-hs(1:ip,0:jp-1))/(redq(1:ip,1:jp)+redq(1:ip,0:jp-1)) & 
+			+ u2(1:ip,1:jp)*rect(1:ip,1:jp))
 
 
+		! ! re-calculate u and v.
+		! u(1:ip,1:jp) = uh_new/(h_new)
+		! v(1:ip,1:jp) = vh_new/h_new
+		! h(1:ip,1:jp) = h_new
 
 		! re-calculate u and v.
-		u(1:ip,1:jp) = uh_new/(h_new)
-		v(1:ip,1:jp) = vh_new/h_new
+		u(1:ip,1:jp) = u_new
+		v(1:ip,1:jp) = v_new
 		h(1:ip,1:jp) = h_new
 
 

--- a/src/driver_code.f90
+++ b/src/driver_code.f90
@@ -38,6 +38,8 @@
 	!>@param[in] redq_s - for efficiency
 	!>@param[in] redq - for efficiency
 	!>@param[in] recq - for efficiency
+	!>@param[in] rect - for efficiency
+	!>@param[in] rect_s - for efficiency
 	!>@param[in] cq_s - for efficiency
 	!>@param[in] cq - for efficiency
 	!>@param[in] dp1 - for efficiency
@@ -63,7 +65,7 @@
 				height, dt, dx, dy, x, y, &
 				phi, theta, phin, thetan, &
 				recqdp, recqdp_s, recqdq_s, redq_s, redq, &
-    			recq, cq_s, cq, dp1, dq,recqdq, &
+    			recq, rect, rect_s, cq_s, cq, dp1, dq,recqdq, &
 			    u_nudge,o_halo, &
 				ipstart, jpstart, coords, &
 				new_file,outputfile, output_interval, nudge, nudge_tau, &
@@ -89,7 +91,7 @@
 		real(wp), dimension(1-o_halo:ipp+o_halo,1-o_halo:jpp+o_halo), &
 					intent(in) :: f_cor, hs, &
     				recqdp, recqdp_s, recqdq_s, redq_s, redq, &
-    				recq, cq_s, cq, dp1, dq, recqdq
+    				recq, rect, rect_s, cq_s, cq, dp1, dq, recqdq
 		real(wp), dimension(1-o_halo:ipp+o_halo,1-o_halo:jpp+o_halo), &
 					intent(inout) :: h, u, v, height
 		real(wp), dimension(1-o_halo:ipp+o_halo,1-o_halo:jpp+o_halo), &
@@ -151,7 +153,7 @@
 			v_old=v
 			call lax_wendroff_ll(ipp,jpp,o_halo,dt,g,u,v,h,hs,re,&
 	    		theta,thetan,dtheta,dthetan, phi, phin, dphi, dphin, f_cor, &
-    			recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, cq, cq_s)	    		
+    			recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, rect, rect_s, cq, cq_s)	    		
 ! 			call lax_wendroff_sphere(ipp,jpp,o_halo,dt,dx,dy,g,u,v,h,hs,re,theta,f_cor)
 			!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/driver_code.f90
+++ b/src/driver_code.f90
@@ -59,6 +59,7 @@
 	!>@param[in] vis_eq: viscosity in equatorial region (needed for stability)
 	!>@param[in] lat_eq: latitude north and south over which to apply vis_eq
 	!>@param[in] dims,id, world_process, ring_comm: mpi variables
+	!>@param[in] new_eqs: whether or not to use the new equations
     subroutine model_driver(ip,ipp, jp,jpp, ntim, f, &
 				re, g, rho, dphi, dtheta, dphin, dthetan, &
 				f_cor,h,hs, u, v, &
@@ -71,14 +72,14 @@
 				new_file,outputfile, output_interval, nudge, nudge_tau, &
 				subgrid_model, viscous_dissipation, dissipate_h,vis, cvis, &
 				vis_eq, lat_eq, &
-				dims,id, world_process, rank, ring_comm)
+				dims,id, world_process, rank, ring_comm, new_eqs)
 		use numerics_type
 		use mpi_module
 		use advection
 
 		implicit none
 		logical, intent(inout) :: new_file
-		logical, intent(in) :: nudge, viscous_dissipation, dissipate_h
+		logical, intent(in) :: nudge, viscous_dissipation, dissipate_h, new_eqs
 		integer(i4b), intent(in) :: ip,ipp, jp,jpp, ntim, o_halo, ipstart, jpstart, &
 									subgrid_model
 		integer(i4b), intent(in) :: id, world_process, ring_comm, rank
@@ -151,10 +152,15 @@
 			h_old=h
 			u_old=u
 			v_old=v
-			call lax_wendroff_ll(ipp,jpp,o_halo,dt,g,u,v,h,hs,re,&
-	    		theta,thetan,dtheta,dthetan, phi, phin, dphi, dphin, f_cor, &
-    			recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, rect, rect_s, cq, cq_s)	    		
-! 			call lax_wendroff_sphere(ipp,jpp,o_halo,dt,dx,dy,g,u,v,h,hs,re,theta,f_cor)
+			if (new_eqs) then
+				call lax_wendroff_sphere(ipp,jpp,o_halo,dt,g,u,v,h,hs,re,&
+					theta,thetan,dtheta,dthetan, phi, phin, dphi, dphin, f_cor, &
+					recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, rect, rect_s, cq, cq_s)
+			else
+				call lax_wendroff_ll(ipp,jpp,o_halo,dt,g,u,v,h,hs,re,&
+					theta,thetan,dtheta,dthetan, phi, phin, dphi, dphin, f_cor, &
+					recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, rect, rect_s, cq, cq_s)
+			endif	    		
 			!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 

--- a/src/driver_code.f90
+++ b/src/driver_code.f90
@@ -153,7 +153,7 @@
 			u_old=u
 			v_old=v
 			if (new_eqs) then
-				call lax_wendroff_sphere(ipp,jpp,o_halo,dt,g,u,v,h,hs,re,&
+				call lax_wendroff_conservative(ipp,jpp,o_halo,dt,g,u,v,h,hs,re,&
 					theta,thetan,dtheta,dthetan, phi, phin, dphi, dphin, f_cor, &
 					recqdq, recqdp, recqdp_s, recqdq_s, redq_s, redq, rect, rect_s, cq, cq_s)
 			else

--- a/src/initialisation.f90
+++ b/src/initialisation.f90
@@ -47,6 +47,8 @@
 	!>@param[inout] redq_s - for efficiency
 	!>@param[inout] redq - for efficiency
 	!>@param[inout] recq - for efficiency
+	!>@param[inout] rect - for efficiency
+	!>@param[inout] rect_s - for efficiency
 	!>@param[inout] cq_s - for efficiency
 	!>@param[inout] cq - for efficiency
 	!>@param[inout] dp1 - for efficiency
@@ -87,7 +89,7 @@
 				height, dt, dx, dy, x, y, &
 				phi, theta, phin, thetan, &
 				recqdp, recqdp_s, recqdq_s, redq_s,redq, &
-				recq, cq_s, cq, dp1, dq, &
+				recq, rect, rect_s, cq_s, cq, dp1, dq, &
 				recqdq, &
 				u_nudge, o_halo, ipstart, jpstart, coords, &
 				inputfile, add_random_height_noise, &
@@ -114,7 +116,7 @@
     									f_cor, h, hs, u, v, height, &
     											dx, dy, x, y, &
     				recqdp, recqdp_s, recqdq_s, redq_s, redq, &
-    				recq, cq_s, cq, dp1, dq, recqdq
+    				recq, rect, rect_s, cq_s, cq, dp1, dq, recqdq
     	real(wp), intent(inout), allocatable, dimension(:) :: &
     									phi, theta, phin, thetan,u_nudge, &
     									dphi, dtheta, dphin, dthetan
@@ -226,6 +228,10 @@
 		allocate( redq(1-o_halo:ipp+o_halo,1-o_halo:jpp+o_halo), STAT = AllocateStatus)
 		if (AllocateStatus /= 0) STOP "*** Not enough memory ***"
 		allocate( recq(1-o_halo:ipp+o_halo,1-o_halo:jpp+o_halo), STAT = AllocateStatus)
+		if (AllocateStatus /= 0) STOP "*** Not enough memory ***"
+		allocate( rect(1-o_halo:ipp+o_halo,1-o_halo:jpp+o_halo), STAT = AllocateStatus)
+		if (AllocateStatus /= 0) STOP "*** Not enough memory ***"
+		allocate( rect_s(1-o_halo:ipp+o_halo,1-o_halo:jpp+o_halo), STAT = AllocateStatus)
 		if (AllocateStatus /= 0) STOP "*** Not enough memory ***"
 		allocate( cq_s(1-o_halo:ipp+o_halo,1-o_halo:jpp+o_halo), STAT = AllocateStatus)
 		if (AllocateStatus /= 0) STOP "*** Not enough memory ***"
@@ -616,6 +622,9 @@
 			cq(:,j)=cos(theta(j))
 			dp1(:,j)=dphi(:)
 			dq(:,j)=dtheta(j)
+
+			rect(:,j)=tan(theta(j))/re
+			rect_s(:,j)=tan(thetan(j))/re
 		enddo
 		
 		

--- a/src/initialisation.f90
+++ b/src/initialisation.f90
@@ -625,9 +625,7 @@
 
 			rect(:,j)=tan(theta(j))/re
 			rect_s(:,j)=tan(thetan(j))/re
-		enddo
-		
-		
+		enddo		
 
 		deallocate(wind)
 		deallocate(latitude)

--- a/src/main.f90
+++ b/src/main.f90
@@ -136,7 +136,7 @@
 				grid1%height, grid1%dt,grid1%dx, grid1%dy, grid1%x, grid1%y, &
 				grid1%phi, grid1%theta, grid1%phin, grid1%thetan, &
    				grid1%recqdp, grid1%recqdp_s, grid1%recqdq_s, grid1%redq_s, grid1%redq, &
-    				grid1%recq, grid1%cq_s, grid1%cq, grid1%dp1, grid1%dq, &
+    				grid1%recq, grid1%rect, grid1%rect_s, grid1%cq_s, grid1%cq, grid1%dp1, grid1%dq, &
     				grid1%recqdq, &
  				grid1%u_nudge,grid1%o_halo, &
 				grid1%ipstart, grid1%jpstart, grid1%coords, &
@@ -174,7 +174,7 @@
 				grid1%height, grid1%dt, grid1%dx, grid1%dy, grid1%x, grid1%y, &
 				grid1%phi, grid1%theta, grid1%phin, grid1%thetan, &
    				grid1%recqdp, grid1%recqdp_s, grid1%recqdq_s, grid1%redq_s, grid1%redq, &
-    			grid1%recq, grid1%cq_s, grid1%cq, grid1%dp1, grid1%dq, &
+    			grid1%recq, grid1%rect, grid1%rect_s, grid1%cq_s, grid1%cq, grid1%dp1, grid1%dq, &
     			grid1%recqdq, &
 				grid1%u_nudge,grid1%o_halo, &
 				grid1%ipstart, grid1%jpstart, grid1%coords, &

--- a/src/main.f90
+++ b/src/main.f90
@@ -183,7 +183,7 @@
 				nm1%subgrid_model, nm1%viscous_dissipation, &
 				nm1%dissipate_h,nm1%vis,nm1%cvis, &
 				nm1%vis_eq,nm1%lat_eq, &
-				mp1%dims,mp1%id, world_process, mp1%rank, mp1%ring_comm)
+				mp1%dims,mp1%id, world_process, mp1%rank, mp1%ring_comm, nm1%new_eqs)
         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 

--- a/src/python/animate_output.py
+++ b/src/python/animate_output.py
@@ -27,7 +27,7 @@ matplotlib.use("Agg")
 warnings.filterwarnings("ignore")
 username = getpass.getuser()
 
-CASSINI_PERSPECTIVE = True
+CASSINI_PERSPECTIVE = False
 
 nc = NetCDFFile("../../tests/output.nc")
 lons = nc.variables["phi"][:]

--- a/src/variables.f90
+++ b/src/variables.f90
@@ -21,7 +21,7 @@
             real(wp), dimension(:,:), allocatable :: f_cor, h, hs, u,v, height, &
             										 dx, dy, x, y, &
     				recqdp, recqdp_s, recqdq_s, redq_s, redq, &
-    				recq, cq_s, cq, dp1, dq, recqdq
+    				recq, rect, rect_s, cq_s, cq, dp1, dq, recqdq
             										 
             real(wp), dimension(:), allocatable :: phi, theta, phin, thetan, u_nudge, &
             	dphi, dtheta, dphin, dthetan

--- a/src/variables.f90
+++ b/src/variables.f90
@@ -41,7 +41,7 @@
             logical :: add_random_height_noise, &
             			initially_geostrophic, &
             			viscous_dissipation, &
-            			dissipate_h, nudge, restart
+            			dissipate_h, nudge, restart, new_eqs
             integer(i4b) :: initial_winds, ip, jp, subgrid_model
             real(wp) :: wind_factor, wind_shift, wind_reduce, vis, &
             			runtime, dt, output_interval, &


### PR DESCRIPTION
Updates the advection file to include a method that uses the conservative form of the Shallow Water equations in geographical coordinates. The main difference is the additional tan terms in the equations. 

![image](https://github.com/UoM-maul1609/shallow-water-model-on-sphere/assets/73986146/5a02eab2-3f8d-43b0-ae54-f48e1c5b7ad2)
