### PR TITLE
Add in the noise stability test code

### DIFF
--- a/config/namelist.in
+++ b/config/namelist.in
@@ -40,4 +40,5 @@
 	nm1%slat_thresh=65.,
 	nm1%nlat_thresh=86.5,
 	nm1%new_eqs=.true,
+	nm1%noise_stability_test=.false,
 	nm1%polar_vortex=.false/

--- a/src/main.f90
+++ b/src/main.f90
@@ -142,7 +142,8 @@
 				nm1%subgrid_model, nm1%viscous_dissipation, &
 				nm1%dissipate_h,nm1%vis,nm1%cvis, &
 				nm1%vis_eq,nm1%lat_eq, &
-				mp1%dims,mp1%id, world_process, mp1%rank, mp1%ring_comm, nm1%new_eqs, nm1%polar_vortex)
+				mp1%dims,mp1%id, world_process, mp1%rank, mp1%ring_comm, nm1%new_eqs, nm1%noise_stability_test, &
+				nm1%polar_vortex, nm1%initial_winds, nm1%u_jet, nm1%jet_noise, nm1%theta_jet, nm1%h_jet)
 
 
         ! TERMINATE MPI

--- a/src/variables.f90
+++ b/src/variables.f90
@@ -36,7 +36,7 @@
             logical :: add_random_height_noise, &
             			initially_geostrophic, &
             			viscous_dissipation, &
-            			dissipate_h, nudge, restart, new_eqs, polar_vortex
+            			dissipate_h, nudge, restart, new_eqs, noise_stability_test, polar_vortex
             integer(i4b) :: initial_winds, ip, jp, subgrid_model
             real(wp) :: wind_factor, wind_shift, wind_reduce, vis, &
             			runtime, dt, output_interval, &


### PR DESCRIPTION
- Add noise subroutine in the initialisation.f90 file.
- Add ability in the driver code to add noise quarter way through the simulation, if the noise_stability_test parameter is set to true.
- Delete unnecessary dissipation code.