### PR TITLE
Commenting out renaming the shell script data files

### DIFF
--- a/src/shell_scripts/batch_runs.sh
+++ b/src/shell_scripts/batch_runs.sh
@@ -40,8 +40,7 @@ ARRAY=(86.5 86.6 86.7 86.8 86.9 87.0 87.1 87.2 87.3 87.4 87.5 87.6 87.7 87.8 87.
 
 ELEMENTS=${#ARRAY[@]} # elements in array
 
-cd ..
-# make
+cd .. && make
 
 rm ../output/animations/animation.gif
 rm ../output/animations/animation.mp4
@@ -85,6 +84,6 @@ for (( i=0; i<ELEMENTS; i++)); do
     mv "../../output/frames/frame.png" "../../output/streamlines/streamlines_${NAME}_${ARRAY[${i}]}.png" 
 
     # rename output.nc file for storage
-    mv "../../tests/output.nc" "../../tests/output_${NAME}_${ARRAY[${i}]}.nc"
+    # mv "../../tests/output.nc" "../../tests/output_${NAME}_${ARRAY[${i}]}.nc"
     cd ..
 done

--- a/src/shell_scripts/large_batch_run.sh
+++ b/src/shell_scripts/large_batch_run.sh
@@ -2,7 +2,7 @@
 # Batch running - large
 
 
-ALL_NAMES=("u_jet" "h_jet" "theta_jet" "jet_noise" "perturb_strength")
+ALL_NAMES=("u_jet" "h_jet" "theta_jet" "jet_noise")
 ELEMENTS_ALL_NAMES=${#ALL_NAMES[@]} # elements in array
 
 cd .. && make
@@ -10,8 +10,7 @@ cd .. && make
 # rm ../output/animations/animation.mp4
 
 for((k=0; k<ELEMENTS_ALL_NAMES; k++)); do
-    cd ~/Documents/Petra/ShallowWaterModelCode/src
-
+    # cd ~/Documents/Petra/ShallowWaterModelCode/src
     NAME=${ALL_NAMES[${k}]}
     if test "${NAME}" = "u_jet"; then
         ARRAY=(6. 6.5 7. 7.5 8. 8.5 9. 9.5 10. 10.5 11. 11.5 12. 12.5 13. 13.5 14. 14.4 15. 15.5 16. 16.5 17. 17.5 18. 18.5 19. 19.5 20. 21. 22. 23. 24. 25. 26. 27. 28. 29. 30. 31. 32.)
@@ -58,7 +57,7 @@ for((k=0; k<ELEMENTS_ALL_NAMES; k++)); do
         mv "../../output/frames/frame.png" "../../output/streamlines/streamlines_${NAME}_${ARRAY[${i}]}.png" 
 
         # rename output.nc file for storage
-        mv "../../tests/output.nc" "../../tests/output_${NAME}_${ARRAY[${i}]}.nc"
+        # mv "../../tests/output.nc" "../../tests/output_${NAME}_${ARRAY[${i}]}.nc"
         cd ..
     done
 done

--- a/src/shell_scripts/pair_run.sh
+++ b/src/shell_scripts/pair_run.sh
@@ -50,12 +50,12 @@ for (( i=0; i<ELEMENTS1; i++)); do
             mv "../../output/frames/frame.png" "../../output/streamlines/streamlines_${NAME1}_${ARRAY1[${i}]}_${NAME2}_${ARRAY2[${j}]}.png" 
 
             # create height and streamlines figure
-            echo "Creating velocity latitude figure"
-            python3 velocity_latitudes.py
-            mv "../../output/velocities/velocity_latitudes.png" "../../output/velocities/velocity_latitudes_${NAME1}_${ARRAY1[${i}]}_${NAME2}_${ARRAY2[${j}]}.png"
+            # echo "Creating velocity latitude figure"
+            # python3 velocity_latitudes.py
+            # mv "../../output/velocities/velocity_latitudes.png" "../../output/velocities/velocity_latitudes_${NAME1}_${ARRAY1[${i}]}_${NAME2}_${ARRAY2[${j}]}.png"
 
             # rename output.nc file for storage
-            mv "../../tests/output.nc" "../../tests/output_${NAME1}_${ARRAY1[${i}]}_${NAME2}_${ARRAY2[${j}]}.nc"
+            # mv "../../tests/output.nc" "../../tests/output_${NAME1}_${ARRAY1[${i}]}_${NAME2}_${ARRAY2[${j}]}.nc"
             cd ..
  			
 	done


### PR DESCRIPTION
- Comments out renaming the shell script data files. This means that only the images are saved, and the data files are overwritten. This is for testing that only requires the end images rather than the data - you can uncomment to save the data again, of course.